### PR TITLE
cli: Rename -tag to -tags

### DIFF
--- a/examples/gen.go
+++ b/examples/gen.go
@@ -1,4 +1,4 @@
 package example
 
 //go:generate cff -file magic.go -genmode source-map .
-//go:generate cff -file magic_v2.go -tag v2 -genmode modifier .
+//go:generate cff -file magic_v2.go -tags v2 -genmode modifier .

--- a/examples/magic_clean_test.go
+++ b/examples/magic_clean_test.go
@@ -37,7 +37,7 @@ func TestGoldenMagic2(t *testing.T) {
 	expectedPath := filepath.Join(t.TempDir(), "magic_v2.go")
 	actualPath := "magic_v2_gen.go"
 
-	cmd := exec.Command("cff", "-genmode=modifier", "-tag=v2", "-file", "magic_v2.go="+expectedPath, ".")
+	cmd := exec.Command("cff", "-genmode=modifier", "-tags=v2", "-file", "magic_v2.go="+expectedPath, ".")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	require.NoError(t, cmd.Run())

--- a/internal/pkg/gopackages.go
+++ b/internal/pkg/gopackages.go
@@ -27,7 +27,7 @@ func (f *GoPackagesLoaderFactory) RegisterFlags(fset *flag.Set) Loader {
 		load: packages.Load,
 	}
 
-	fset.Var(flag.AsList(&loader.tags), "tag",
+	fset.Var(flag.AsList(&loader.tags), "tags",
 		"Build tags to load packages with in addition to the 'cff' tag.\n"+
 			"This flag may be provided multiple times.")
 

--- a/internal/pkg/gopackages_test.go
+++ b/internal/pkg/gopackages_test.go
@@ -23,7 +23,7 @@ func TestGoPackagesLoader_Integration(t *testing.T) {
 
 	parser := flag.NewSet("cff")
 	loader := factory.RegisterFlags(parser)
-	require.NoError(t, parser.Parse([]string{"-tag", "foo,cff"}),
+	require.NoError(t, parser.Parse([]string{"-tags", "foo,cff"}),
 		"parse arguments")
 
 	fset := token.NewFileSet()


### PR DESCRIPTION
This matches the flag accepted by other command for this purpose
including `go build`, `go test`, `staticcheck`, etc.

Resolves #10
