### PR TITLE
compile: Make 'cff' constraint required

### DIFF
--- a/cmd/cff/main.go
+++ b/cmd/cff/main.go
@@ -73,7 +73,14 @@ func main() {
 	}
 }
 
-var _loaderFactory pkg.LoaderFactory = new(pkg.GoPackagesLoaderFactory)
+var (
+	// Defines how we load package information.
+	_loaderFactory pkg.LoaderFactory = new(pkg.GoPackagesLoaderFactory)
+
+	// Whether files that use cff.Flow/cff.Parallel must have a 'cff' build
+	// constraint.
+	_requireBuildTag = true
+)
 
 func run(args []string) error {
 	defer func() {
@@ -108,6 +115,7 @@ func run(args []string) error {
 		Fset:               fset,
 		InstrumentAllTasks: f.AutoInstrument,
 		GenMode:            f.GenMode,
+		RequireBuildTag:    _requireBuildTag,
 	}
 
 	// If --file was provided, only the requested files will be processed.

--- a/internal/aquaregia_test.go
+++ b/internal/aquaregia_test.go
@@ -399,6 +399,14 @@ var codeGenerateFailCases = map[string][]errorCase{
 				"ParallelMapEndWithContinueOnErrorAndInstrument",
 			},
 		},
+		{
+			File:         "missing-tag.go",
+			ErrorMatches: `files that use cff.(Flow|Parallel) must be tagged with the 'cff' constraint`,
+			TestFuncs: []string{
+				"FlowWithoutTag",
+				"ParallelWithoutTag",
+			},
+		},
 	},
 	"cycles": {
 		{
@@ -439,7 +447,10 @@ func TestCodeGenerateFails(t *testing.T) {
 			require.NoError(t, err, "could not load packages")
 			require.NotEmpty(t, pkgs, "didn't find any packages")
 
-			processor := Processor{Fset: fset}
+			processor := Processor{
+				Fset:            fset,
+				RequireBuildTag: true,
+			}
 
 			for _, gopkg := range pkgs {
 				pkg := newPackage(gopkg)

--- a/internal/failing_tests/bad-inputs/missing-tag.go
+++ b/internal/failing_tests/bad-inputs/missing-tag.go
@@ -1,0 +1,33 @@
+//go:build failing
+// +build failing
+
+package badinputs
+
+import (
+	"context"
+	"strconv"
+
+	"go.uber.org/cff"
+)
+
+func FlowWithoutTag() error {
+	var message string
+	return cff.Flow(context.Background(),
+		cff.Params(1),
+		cff.Results(&message),
+		cff.Task(
+			func(i int) string {
+				return strconv.Itoa(i)
+			},
+		),
+	)
+}
+
+func ParallelWithoutTag() error {
+	return cff.Parallel(context.Background(),
+		cff.Slice(
+			func(int, string) {},
+			[]string{"foo", "bar"},
+		),
+	)
+}

--- a/internal/process.go
+++ b/internal/process.go
@@ -13,6 +13,7 @@ type Processor struct {
 	Fset               *token.FileSet
 	InstrumentAllTasks bool
 	GenMode            flag.Mode
+	RequireBuildTag    bool
 }
 
 // Process processes a single CFF file.
@@ -22,6 +23,7 @@ func (p *Processor) Process(pkg *pkg.Package, file *ast.File, outputPath string)
 		Info:               pkg.TypesInfo,
 		Package:            pkg.Types,
 		InstrumentAllTasks: p.InstrumentAllTasks,
+		RequireBuildTag:    p.RequireBuildTag,
 	})
 
 	f, err := c.CompileFile(file, pkg)


### PR DESCRIPTION
This adds a new option to the compiler which, when enabled,
checks that the 'cff' build constraint is present in a file.

The option is always enabled for the 'cff' binary,
but we can disable it for Bazel the same way we install
a different package loader.

This will ensure that someone does not attempt to use cff code
generation directives outside a file that isn't tagged 'cff',
because if they do that they'll end up with a panicking binary
or code that fails to compile (because of duplicate declarations).

Note that we only check for the *presence* of the tag,
not whether it evaluates to true.
We can assume that it evaluates to true because the package loader
always passes that in with `-tags cff`.

Resolves #4
