### PR TITLE
cli: Don't panic on errors

### DIFF
--- a/cmd/cff/main.go
+++ b/cmd/cff/main.go
@@ -83,13 +83,6 @@ var (
 )
 
 func run(args []string) error {
-	defer func() {
-		if err := recover(); err != nil {
-			fmt.Println("You've encountered a CFFv2 bug! Please report this http://t.uber.com/cff-bug")
-			panic(err)
-		}
-	}()
-
 	loader, f, err := parseArgs(os.Stderr, args)
 	if err != nil {
 		return err

--- a/cmd/cff/main_test.go
+++ b/cmd/cff/main_test.go
@@ -86,3 +86,10 @@ func TestParseArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestMain_ErrorNoPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		err := run([]string{"-unknown-flag"})
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
This behavior to always panic on any error
was an artifact of having a more visible message
when there were errors using cff in a Bazel context.
This is no longer necessary.
