### PR TITLE
Rename BeginFlow to NewScheduler

### DIFF
--- a/examples/magic_gen.go
+++ b/examples/magic_gen.go
@@ -111,7 +111,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _35_19, Emitter: schedEmitter,
 			},
@@ -586,7 +586,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _80_19, Emitter: schedEmitter,
 				ContinueOnError: _81_23,

--- a/examples/magic_v2_gen.go
+++ b/examples/magic_v2_gen.go
@@ -259,7 +259,7 @@ func _cffFlowmagicv2_32_9(
 
 	schedEmitter := emitter.SchedulerInit(schedInfo)
 
-	sched := cff.BeginFlow(
+	sched := cff.NewScheduler(
 		cff.SchedulerParams{
 			Concurrency: _35_19, Emitter: schedEmitter,
 		},

--- a/internal/modifier/templates/flow.go.tmpl
+++ b/internal/modifier/templates/flow.go.tmpl
@@ -49,7 +49,7 @@ func {{ .FuncExpr }}(
 
 	schedEmitter := emitter.SchedulerInit(schedInfo)
 
-	sched := {{ $cff }}.BeginFlow(
+	sched := {{ $cff }}.NewScheduler(
 		{{ $cff }}.SchedulerParams{
 			{{ with .Concurrency -}} Concurrency: {{ expr . }}, {{ end -}}
 			Emitter: schedEmitter,

--- a/internal/templates/flow/flow.go.tmpl
+++ b/internal/templates/flow/flow.go.tmpl
@@ -46,7 +46,7 @@
 
 	schedEmitter := emitter.SchedulerInit(schedInfo)
 
-	sched := {{ $cff }}.BeginFlow(
+	sched := {{ $cff }}.NewScheduler(
 		{{ $cff }}.SchedulerParams{
 			{{ with .Concurrency -}} Concurrency: {{ expr . }}, {{ end -}}
 			Emitter: schedEmitter,

--- a/internal/templates/parallel/parallel.go.tmpl
+++ b/internal/templates/parallel/parallel.go.tmpl
@@ -46,7 +46,7 @@
 
 	schedEmitter := emitter.SchedulerInit(schedInfo)
 
-	sched := {{ $cff }}.BeginFlow(
+	sched := {{ $cff }}.NewScheduler(
 		{{ $cff }}.SchedulerParams{
 			{{ with .Concurrency -}} Concurrency:  {{ expr . }}, {{- end -}}
 			Emitter: schedEmitter,

--- a/internal/tests/basic/basic_gen.go
+++ b/internal/tests/basic/basic_gen.go
@@ -71,7 +71,7 @@ func SimpleFlow() (string, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -336,7 +336,7 @@ func NoParamsFlow(ctx context.Context) (io.Reader, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -509,7 +509,7 @@ func SerialFailableFlow(ctx context.Context, f1, f2 func() error) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -743,7 +743,7 @@ func ProduceMultiple() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/benchmark/benchmark_gen.go
+++ b/internal/tests/benchmark/benchmark_gen.go
@@ -67,7 +67,7 @@ func Baseline() float64 {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/benchmark/benchmark_predicate_gen.go
+++ b/internal/tests/benchmark/benchmark_predicate_gen.go
@@ -81,7 +81,7 @@ func PredicateCombined() float64 {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _38_19, Emitter: schedEmitter,
 			},
@@ -252,7 +252,7 @@ func PredicateSplit() float64 {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _66_19, Emitter: schedEmitter,
 			},

--- a/internal/tests/builtincallexpr/builtincallexpr_gen.go
+++ b/internal/tests/builtincallexpr/builtincallexpr_gen.go
@@ -54,7 +54,7 @@ func Flow(s string, buf io.Writer) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/earlyresult/earlyresult_gen.go
+++ b/internal/tests/earlyresult/earlyresult_gen.go
@@ -79,7 +79,7 @@ func EarlyResult(ctx context.Context) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -409,7 +409,7 @@ func ConsumesResult() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/externalpackage/externalpackage_gen.go
+++ b/internal/tests/externalpackage/externalpackage_gen.go
@@ -56,7 +56,7 @@ func NestedType(ctx context.Context, driverUUID uuid.UUID) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -170,7 +170,7 @@ func ImplicitType(ctx context.Context) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/fallbackwith/fallbackwith_gen.go
+++ b/internal/tests/fallbackwith/fallbackwith_gen.go
@@ -54,7 +54,7 @@ func Serial(e error, r string) (string, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -171,7 +171,7 @@ func NoOutput() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -289,7 +289,7 @@ func Panic() (string, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/importcollision/import_collision_gen.go
+++ b/internal/tests/importcollision/import_collision_gen.go
@@ -63,7 +63,7 @@ func Flow() (string, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff2.BeginFlow(
+		sched := cff2.NewScheduler(
 			cff2.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/importstmt/importstmt_gen.go
+++ b/internal/tests/importstmt/importstmt_gen.go
@@ -55,7 +55,7 @@ func Flow() (int, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/insidegeneric/producer_gen.go
+++ b/internal/tests/insidegeneric/producer_gen.go
@@ -61,7 +61,7 @@ func JoinTwo[A, B, C any](
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -285,7 +285,7 @@ func JoinMany[T any](producers ...Producer[T]) ([]T, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/modifier/collision/file1_gen.go
+++ b/internal/tests/modifier/collision/file1_gen.go
@@ -65,7 +65,7 @@ func _cffFlowfile1_15_9(
 
 	schedEmitter := emitter.SchedulerInit(schedInfo)
 
-	sched := cff.BeginFlow(
+	sched := cff.NewScheduler(
 		cff.SchedulerParams{
 			Concurrency: _16_19, Emitter: schedEmitter,
 		},

--- a/internal/tests/modifier/collision/file2_gen.go
+++ b/internal/tests/modifier/collision/file2_gen.go
@@ -65,7 +65,7 @@ func _cffFlowfile2_15_9(
 
 	schedEmitter := emitter.SchedulerInit(schedInfo)
 
-	sched := cff.BeginFlow(
+	sched := cff.NewScheduler(
 		cff.SchedulerParams{
 			Concurrency: _16_19, Emitter: schedEmitter,
 		},

--- a/internal/tests/modifier/simple/simple_gen.go
+++ b/internal/tests/modifier/simple/simple_gen.go
@@ -178,7 +178,7 @@ func _cffFlowsimple_21_9(
 
 	schedEmitter := emitter.SchedulerInit(schedInfo)
 
-	sched := cff.BeginFlow(
+	sched := cff.NewScheduler(
 		cff.SchedulerParams{
 			Concurrency: _22_19, Emitter: schedEmitter,
 		},
@@ -399,7 +399,7 @@ func _cffFlowsimple_55_9(
 
 	schedEmitter := emitter.SchedulerInit(schedInfo)
 
-	sched := cff.BeginFlow(
+	sched := cff.NewScheduler(
 		cff.SchedulerParams{
 			Concurrency: _56_19, Emitter: schedEmitter,
 		},
@@ -582,7 +582,7 @@ func _cffFlowsimple_82_9(
 
 	schedEmitter := emitter.SchedulerInit(schedInfo)
 
-	sched := cff.BeginFlow(
+	sched := cff.NewScheduler(
 		cff.SchedulerParams{
 			Concurrency: _83_19, Emitter: schedEmitter,
 		},
@@ -770,7 +770,7 @@ func _cffFlowsimple_106_9(
 
 	schedEmitter := emitter.SchedulerInit(schedInfo)
 
-	sched := cff.BeginFlow(
+	sched := cff.NewScheduler(
 		cff.SchedulerParams{
 			Concurrency: _107_19, Emitter: schedEmitter,
 		},

--- a/internal/tests/named_imports/named_imports_gen.go
+++ b/internal/tests/named_imports/named_imports_gen.go
@@ -53,7 +53,7 @@ func run(ctx newctx.Context) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cffv2.BeginFlow(
+		sched := cffv2.NewScheduler(
 			cffv2.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/nested_child/nested_child_gen.go
+++ b/internal/tests/nested_child/nested_child_gen.go
@@ -54,7 +54,7 @@ func Itoa(ctx context.Context, i int) (s string, err error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/nested_parent/nested_parent_gen.go
+++ b/internal/tests/nested_parent/nested_parent_gen.go
@@ -55,7 +55,7 @@ func Parent(ctx context.Context, i int) (s string, err error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/noresults/noresults_gen.go
+++ b/internal/tests/noresults/noresults_gen.go
@@ -72,7 +72,7 @@ func (h *H) Swallow(ctx context.Context, req string) (err error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -228,7 +228,7 @@ func (h *H) TripleSwallow(ctx context.Context, req string) (err error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -428,7 +428,7 @@ func UnusedInputInvoke() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/panic/panic_gen.go
+++ b/internal/tests/panic/panic_gen.go
@@ -63,7 +63,7 @@ func (p *Panicker) FlowPanicsParallel() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -268,7 +268,7 @@ func (p *Panicker) FlowPanicsSerial() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/parallel/parallel_gen.go
+++ b/internal/tests/parallel/parallel_gen.go
@@ -70,7 +70,7 @@ func TasksAndTask(m *sync.Map) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _20_19, Emitter: schedEmitter,
 			},
@@ -256,7 +256,7 @@ func TasksWithError() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _41_19, Emitter: schedEmitter,
 			},
@@ -372,7 +372,7 @@ func TasksWithPanic() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _54_19, Emitter: schedEmitter,
 			},
@@ -491,7 +491,7 @@ func MultipleTasks(c chan<- string) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _72_19, Emitter: schedEmitter,
 			},
@@ -645,7 +645,7 @@ func ContextErrorBefore(ctx context.Context, src, target []int) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _89_19, Emitter: schedEmitter,
 			},
@@ -768,7 +768,7 @@ func ContextErrorInFlight(ctx context.Context, cancel func(), src, target []int)
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _104_19, Emitter: schedEmitter,
 			},
@@ -954,7 +954,7 @@ func TaskWithError() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _126_19, Emitter: schedEmitter,
 			},
@@ -1070,7 +1070,7 @@ func TaskWithPanic() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _139_19, Emitter: schedEmitter,
 			},
@@ -1190,7 +1190,7 @@ func MultipleTask(src, target []int) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _158_19, Emitter: schedEmitter,
 			},
@@ -1369,7 +1369,7 @@ func ContinueOnError(src []int, target []int) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _178_19, Emitter: schedEmitter,
 				ContinueOnError: _179_23,
@@ -1621,7 +1621,7 @@ func ContinueOnErrorBoolExpr(src, target []int, fn func() bool) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _221_19, Emitter: schedEmitter,
 				ContinueOnError: _222_23,
@@ -1814,7 +1814,7 @@ func ContinueOnErrorCancelled(ctx context.Context, src []int, target []int) erro
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _255_19, Emitter: schedEmitter,
 				ContinueOnError: _256_23,
@@ -1940,7 +1940,7 @@ func ContinueOnErrorCancelledDuring(ctx context.Context, cancel func(), src []in
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _271_19, Emitter: schedEmitter,
 				ContinueOnError: _272_23,
@@ -2137,7 +2137,7 @@ func SliceMultiple(srcA, srcB, targetA, targetB []int) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _297_19, Emitter: schedEmitter,
 			},
@@ -2271,7 +2271,7 @@ func SliceNoIndex(srcA, srcB, targetA, targetB []int) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _318_19, Emitter: schedEmitter,
 			},
@@ -2401,7 +2401,7 @@ func SliceWrapped(src, target manyInts) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _341_19, Emitter: schedEmitter,
 			},
@@ -2514,7 +2514,7 @@ func AssignSliceItems(src, target []string, keepgoing bool) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _357_19, Emitter: schedEmitter,
 				ContinueOnError: _358_23,
@@ -2618,7 +2618,7 @@ func SliceEnd(src []int, sliceFn func(idx, val int) error, sliceEndFn func()) (e
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _381_19, Emitter: schedEmitter,
 			},
@@ -2738,7 +2738,7 @@ func SliceEndWithErr(src []int, sliceFn func(idx, val int) error, sliceEndFn fun
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _396_19, Emitter: schedEmitter,
 			},
@@ -2858,7 +2858,7 @@ func SliceEndWithCtx(src []int, sliceFn func(idx, val int) error, sliceEndFn fun
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _411_19, Emitter: schedEmitter,
 			},
@@ -2978,7 +2978,7 @@ func SliceEndWithCtxAndErr(src []int, sliceFn func(idx, val int) error, sliceEnd
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _426_19, Emitter: schedEmitter,
 			},
@@ -3108,7 +3108,7 @@ func AssignMapItems(src map[string]int, keys []string, values []int, keepgoing b
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _440_19, Emitter: schedEmitter,
 				ContinueOnError: _441_23,
@@ -3218,7 +3218,7 @@ func ForEachMapItem[K comparable, V any](
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _470_19, Emitter: schedEmitter,
 			},
@@ -3341,7 +3341,7 @@ func ForEachMapItemError[K comparable, V any](
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _484_19, Emitter: schedEmitter,
 			},
@@ -3465,7 +3465,7 @@ func ForEachMapItemContext[K comparable, V any](
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _499_19, Emitter: schedEmitter,
 			},

--- a/internal/tests/predicate/predicate_gen.go
+++ b/internal/tests/predicate/predicate_gen.go
@@ -55,7 +55,7 @@ func Simple(f func(), pred bool) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -209,7 +209,7 @@ func SimpleWithContextTask() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -363,7 +363,7 @@ func SimpleWithContextPredicate() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -517,7 +517,7 @@ func SimpleWithContextTaskAndPredicate() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -677,7 +677,7 @@ func ExtraDependencies() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -923,7 +923,7 @@ func MultiplePredicates() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -1149,7 +1149,7 @@ func Panicked() error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -1303,7 +1303,7 @@ func PanickedWithFallback() (string, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/sandwich/aflow_gen.go
+++ b/internal/tests/sandwich/aflow_gen.go
@@ -47,7 +47,7 @@ func aFlow() (s string, err error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/sandwich/bflow_gen.go
+++ b/internal/tests/sandwich/bflow_gen.go
@@ -47,7 +47,7 @@ func bFlow() (s string, err error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/setconcurrency/setconcurrency_gen.go
+++ b/internal/tests/setconcurrency/setconcurrency_gen.go
@@ -62,7 +62,7 @@ func NumWorkers(conc int) (int, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Concurrency: _27_19, Emitter: schedEmitter,
 			},
@@ -185,7 +185,7 @@ func NumWorkersNoArg() (int, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/shadowedvar/param_expr_gen.go
+++ b/internal/tests/shadowedvar/param_expr_gen.go
@@ -62,7 +62,7 @@ func ParamOrder(track *orderCheck) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -189,7 +189,7 @@ func NilParam() {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff.BeginFlow(
+		sched := cff.NewScheduler(
 			cff.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/internal/tests/shadowedvar/shadowedvar_gen.go
+++ b/internal/tests/shadowedvar/shadowedvar_gen.go
@@ -54,7 +54,7 @@ func CtxConflict(ctx string) (string, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff2.BeginFlow(
+		sched := cff2.NewScheduler(
 			cff2.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -187,7 +187,7 @@ func CtxConflictParallel(ctx string) (string, string, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff2.BeginFlow(
+		sched := cff2.NewScheduler(
 			cff2.SchedulerParams{
 				Emitter: schedEmitter,
 			},
@@ -341,7 +341,7 @@ func CtxConflictSlice(ctx string, target []string) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff2.BeginFlow(
+		sched := cff2.NewScheduler(
 			cff2.SchedulerParams{
 				Concurrency: _51_20, Emitter: schedEmitter,
 			},
@@ -445,7 +445,7 @@ func CtxConflictMap(ctx int, input map[int]int) ([]int, error) {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff2.BeginFlow(
+		sched := cff2.NewScheduler(
 			cff2.SchedulerParams{
 				Concurrency: _68_20, Emitter: schedEmitter,
 			},
@@ -545,7 +545,7 @@ func PredicateCtxConflict(f func(), ctx bool) error {
 
 		schedEmitter := emitter.SchedulerInit(schedInfo)
 
-		sched := cff2.BeginFlow(
+		sched := cff2.NewScheduler(
 			cff2.SchedulerParams{
 				Emitter: schedEmitter,
 			},

--- a/scheduler.go
+++ b/scheduler.go
@@ -36,16 +36,16 @@ type SchedulerParams struct {
 	ContinueOnError bool
 }
 
-// BeginFlow begins execution of a flow with a maximum of n workers. Enqueue
+// NewScheduler returns a new Scheduler with a maximum of n workers. Enqueue
 // jobs into the returned scheduler in topological order using the Enqueue
 // method, and wait for results with Wait.
 //
-//	sched := cff.BeginFlow(..)
+//	sched := cff.NewScheduler(..)
 //	j1 := sched.Enqueue(cff.Job{...}
 //	j2 := sched.Enqueue(cff.Job{..., Dependencies: []*cff.ScheduledJob{j1}}
 //	// ...
 //	err := sched.Wait()
-func BeginFlow(p SchedulerParams) *scheduler.Scheduler {
+func NewScheduler(p SchedulerParams) *scheduler.Scheduler {
 	cfg := scheduler.Config{
 		Concurrency:     p.Concurrency,
 		Emitter:         adaptSchedulerEmitter(p.Emitter),


### PR DESCRIPTION
This renames cff.BeginFlow to cff.BeginScheduler since it's used by not just Flow but also Parallel (and any other things in the future).

Fix #26.