### PR TITLE
naming: Use 'cff' everywhere, not CFF

### DIFF
--- a/cff.go
+++ b/cff.go
@@ -7,8 +7,8 @@ package cff
 
 import "context"
 
-const _noGenMsg = `If you're seeing this error, you probably built code that uses CFF without processing it with CFF.
-Run 'cff ./...' to ensure that the code you're running is processed through CFF.`
+const _noGenMsg = `If you're seeing this error, you probably built code that uses cff without processing it with cff.
+Ensure that .go files that use cff have '//go:build cff' on top and run 'cff ./...'`
 
 // NOTE: All code generation directives must be added to this file. The list
 // of directives is updated automatically based on the contents of this file.
@@ -130,7 +130,7 @@ func InstrumentFlow(name string) Option {
 	panic(_noGenMsg)
 }
 
-// Concurrency specifies the maximum number of goroutines CFF should use to
+// Concurrency specifies the maximum number of goroutines cff should use to
 // execute the tasks of this Flow.
 //
 // Defaults to max(GOMAXPROCS, 4).
@@ -164,7 +164,7 @@ func ContinueOnError(bool) Option {
 	panic(_noGenMsg)
 }
 
-// Flow specifies a single Flow for execution with CFF. The provided context
+// Flow specifies a single Flow for execution with cff. The provided context
 // is made available to all tasks in the Flow.
 //
 // A Flow MUST have at least one Task (specified with Task or Tasks), and at
@@ -249,7 +249,7 @@ func Invoke(enable bool) TaskOption {
 	panic(_noGenMsg)
 }
 
-// Parallel specifies a Parallel operation for execution with CFF. The provided
+// Parallel specifies a Parallel operation for execution with cff. The provided
 // context is made available to all tasks in the Parallel.
 //
 // A Parallel MUST have at least one Tasks function.

--- a/cmd/cff/main.go
+++ b/cmd/cff/main.go
@@ -40,7 +40,7 @@ func parseArgs(stderr io.Writer, args []string) (pkg.Loader, *params, error) {
 		"When cff processes a file, it generates sibling files with a _gen suffix next to the original files.\n"+
 		"Use the form -file=PATH=OUTPUT to specify a different path for the output file.")
 
-	fset.Var(&opts.GenMode, "genmode", "Use the specified CFF code generation mode.\n"+
+	fset.Var(&opts.GenMode, "genmode", "Use the specified cff code generation mode.\n"+
 		"Valid values are: base, modifier, source-map. Defaults to base.")
 
 	fset.BoolVar(&opts.AutoInstrument, "auto-instrument", false,

--- a/emitter.go
+++ b/emitter.go
@@ -19,20 +19,20 @@ type Emitter interface {
 	// ParallelInit returns a ParallelEmitter which could be memoized based on
 	// parallel name.
 	ParallelInit(*ParallelInfo) ParallelEmitter
-	// SchedulerInit returns an emitter for the CFF scheduler.
+	// SchedulerInit returns an emitter for the cff scheduler.
 	SchedulerInit(s *SchedulerInfo) SchedulerEmitter
 }
 
-// SchedulerState describes the status of jobs managed by the CFF scheduler.
+// SchedulerState describes the status of jobs managed by the cff scheduler.
 type SchedulerState = scheduler.State
 
-// SchedulerEmitter provides observability into the state of the CFF
+// SchedulerEmitter provides observability into the state of the cff
 // scheduler.
 //
 // WARNING: Do not use this API.
 // We intend to replace it in an upcoming release.
 type SchedulerEmitter interface {
-	// EmitScheduler emits the state of the CFF scheduler.
+	// EmitScheduler emits the state of the cff scheduler.
 	EmitScheduler(s SchedulerState)
 }
 
@@ -55,7 +55,7 @@ type FlowInfo struct {
 	Line, Column int
 }
 
-// DirectiveInfo provides information to uniquely identify a CFF Directive.
+// DirectiveInfo provides information to uniquely identify a cff Directive.
 type DirectiveInfo struct {
 	Name string
 	// Directive is the type of directive (e.g flow or parallel)

--- a/emitter_stack.go
+++ b/emitter_stack.go
@@ -170,7 +170,7 @@ func (es emitterStack) SchedulerInit(info *SchedulerInfo) SchedulerEmitter {
 
 type schedulerEmitterStack []SchedulerEmitter
 
-// EmitScheduler emits the state of the CFF scheduler.
+// EmitScheduler emits the state of the cff scheduler.
 func (ses schedulerEmitterStack) EmitScheduler(s SchedulerState) {
 	for _, e := range ses {
 		e.EmitScheduler(s)

--- a/internal/aquaregia_test.go
+++ b/internal/aquaregia_test.go
@@ -22,7 +22,7 @@ const (
 type errorCase struct {
 	// File is the file where errors matching this case are found.
 	File string
-	// ErrorMatches is the error expected when compiling CFF code.
+	// ErrorMatches is the error expected when compiling cff code.
 	ErrorMatches string
 	// TestFuncs are test function names where errors matching this
 	// case are found.
@@ -60,7 +60,7 @@ var codeGenerateFailCases = map[string][]errorCase{
 		{
 			File:         "cff-flow-arguments.go",
 			ErrorMatches: "expected cff call but got field ProvidesBad func\\(\\) go.uber.org/cff.Option",
-			TestFuncs:    []string{"FlowArgumentNonCFF"},
+			TestFuncs:    []string{"FlowArgumentNonCff"},
 		},
 		{
 			File:         "cff-flow-arguments.go",
@@ -110,12 +110,12 @@ var codeGenerateFailCases = map[string][]errorCase{
 		{
 			File:         "cff-task-arguments.go",
 			ErrorMatches: `unexpected code generation directive "Instrument": only cff.Flow or cff.Parallel may be called at the top-level`,
-			TestFuncs:    []string{"ExpectedFlowArgumentsCallExpressions", "ExpectedFlowArgumentsNotCFF"},
+			TestFuncs:    []string{"ExpectedFlowArgumentsCallExpressions", "ExpectedFlowArgumentsNotCff"},
 		},
 		{
 			File:         "cff-task-arguments.go",
 			ErrorMatches: "only cff functions may be passed as task options: found package \"go.uber.org/cff/internal/failing_tests/bad-inputs\"",
-			TestFuncs:    []string{"ExpectedFlowArgumentsNotCFF"},
+			TestFuncs:    []string{"ExpectedFlowArgumentsNotCff"},
 		},
 		{
 			File:         "cff-task-arguments.go",
@@ -130,7 +130,7 @@ var codeGenerateFailCases = map[string][]errorCase{
 		{
 			File:         "cff-task-arguments.go",
 			ErrorMatches: "expected function, got int",
-			TestFuncs:    []string{"ExpectedTasksBadCallExprNotCFF"},
+			TestFuncs:    []string{"ExpectedTasksBadCallExprNotCff"},
 		},
 		{
 			File:         "context-predicate.go",
@@ -195,7 +195,7 @@ var codeGenerateFailCases = map[string][]errorCase{
 		{
 			File:         "instrument.go",
 			ErrorMatches: "cff.Instrument requires a cff\\.Emitter to be provided: use cff\\.WithEmitter",
-			TestFuncs:    []string{"MissingCFFLoggerAndMetrics"},
+			TestFuncs:    []string{"MissingCffLoggerAndMetrics"},
 		},
 
 		{

--- a/internal/buildtag.go
+++ b/internal/buildtag.go
@@ -9,14 +9,14 @@ import (
 	"io"
 )
 
-// invertCFFConstraint takes the address of a parsed
+// invertCffConstraint takes the address of a parsed
 // build tag (// +build) or constraint (//go:build)
 // and modifies it in-place to invert all instances of the "cff" tag.
-func invertCFFConstraint(exp *constraint.Expr) {
+func invertCffConstraint(exp *constraint.Expr) {
 	switch ex := (*exp).(type) {
 	case *constraint.AndExpr:
-		invertCFFConstraint(&ex.X)
-		invertCFFConstraint(&ex.Y)
+		invertCffConstraint(&ex.X)
+		invertCffConstraint(&ex.Y)
 	case *constraint.NotExpr:
 		// Special-case: If "X" in "!X" is "cff",
 		// just remove the "!".
@@ -24,10 +24,10 @@ func invertCFFConstraint(exp *constraint.Expr) {
 			*exp = ex.X
 			return
 		}
-		invertCFFConstraint(&ex.X)
+		invertCffConstraint(&ex.X)
 	case *constraint.OrExpr:
-		invertCFFConstraint(&ex.X)
-		invertCFFConstraint(&ex.Y)
+		invertCffConstraint(&ex.X)
+		invertCffConstraint(&ex.Y)
 	case *constraint.TagExpr:
 		if ex.Tag == "cff" {
 			*exp = &constraint.NotExpr{X: ex}
@@ -35,7 +35,7 @@ func invertCFFConstraint(exp *constraint.Expr) {
 	}
 }
 
-// hasCFFTag reports whether a constraint contains the 'cff' tag.
+// hasCffTag reports whether a constraint contains the 'cff' tag.
 //
 // Note that this does not evaluate whether the constraint evaluates to true,
 // only that it exists.
@@ -47,7 +47,7 @@ func invertCFFConstraint(exp *constraint.Expr) {
 // 'bar' is disabled because we don't care at this point in the program.
 // We can assume that the constraint for 'cff' evaluates to true because the
 // package loader wouldn't have picked up this file otherwise.
-func hasCFFTag(exp constraint.Expr) (found bool) {
+func hasCffTag(exp constraint.Expr) (found bool) {
 	exp.Eval(func(tag string) bool {
 		if tag == "cff" {
 			found = true
@@ -58,8 +58,8 @@ func hasCFFTag(exp constraint.Expr) (found bool) {
 	return found
 }
 
-// fileHasCFFTag reports whether a file has the 'cff' tag in its constraints.
-func fileHasCFFTag(f *ast.File) bool {
+// fileHasCffTag reports whether a file has the 'cff' tag in its constraints.
+func fileHasCffTag(f *ast.File) bool {
 	for _, group := range f.Comments {
 		// Ignore comments after the package clause
 		// because build constraints are allowed only before that.
@@ -73,7 +73,7 @@ func fileHasCFFTag(f *ast.File) bool {
 				continue // not a constraint
 			}
 
-			if hasCFFTag(exp) {
+			if hasCffTag(exp) {
 				return true
 			}
 		}
@@ -82,10 +82,10 @@ func fileHasCFFTag(f *ast.File) bool {
 	return false
 }
 
-// writeInvertedCFFTag writes the provided byte slice to the io.Writer,
+// writeInvertedCffTag writes the provided byte slice to the io.Writer,
 // accounting for any "cff" build constraints in the byte slice
 // by inverting them.
-func writeInvertedCFFTag(w io.Writer, bs []byte) error {
+func writeInvertedCffTag(w io.Writer, bs []byte) error {
 	// This reduces the unnecessary if err != nil statements below.
 	errw := stickyErrWriter{W: w}
 	w = &errw
@@ -108,7 +108,7 @@ func writeInvertedCFFTag(w io.Writer, bs []byte) error {
 			fmt.Fprintln(w, line)
 			continue
 		}
-		invertCFFConstraint(&expr)
+		invertCffConstraint(&expr)
 
 		if isGoBuild {
 			fmt.Fprintf(w, "//go:build %v\n", expr.String())

--- a/internal/buildtag_test.go
+++ b/internal/buildtag_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHasCFFTag(t *testing.T) {
+func TestHasCffTag(t *testing.T) {
 	tests := []struct {
 		desc string
 		give string
@@ -60,12 +60,12 @@ func TestHasCFFTag(t *testing.T) {
 			exp, err := constraint.Parse(tt.give)
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.want, hasCFFTag(exp))
+			assert.Equal(t, tt.want, hasCffTag(exp))
 		})
 	}
 }
 
-func TestFileHasCFFTag(t *testing.T) {
+func TestFileHasCffTag(t *testing.T) {
 	tests := []struct {
 		desc string
 		give []string
@@ -119,12 +119,12 @@ func TestFileHasCFFTag(t *testing.T) {
 			fset := token.NewFileSet()
 			f, err := parser.ParseFile(fset, "foo.go", contents, parser.ParseComments)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, fileHasCFFTag(f))
+			assert.Equal(t, tt.want, fileHasCffTag(f))
 		})
 	}
 }
 
-func TestWriteInvertedCFFTag(t *testing.T) {
+func TestWriteInvertedCffTag(t *testing.T) {
 	tests := []struct {
 		desc string
 		give string
@@ -210,7 +210,7 @@ func TestWriteInvertedCFFTag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			var got bytes.Buffer
-			err := writeInvertedCFFTag(&got, []byte(tt.give))
+			err := writeInvertedCffTag(&got, []byte(tt.give))
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got.String())
 		})

--- a/internal/compile.go
+++ b/internal/compile.go
@@ -202,7 +202,7 @@ func (c *compiler) compileFile(astFile *ast.File, pkg *pkg.Package) *file {
 		}
 	})
 
-	if c.requireBuildTag && !fileHasCFFTag(astFile) {
+	if c.requireBuildTag && !fileHasCffTag(astFile) {
 		msgfmt := "files that use %v must be tagged with the 'cff' constraint: " +
 			"fix by adding '//go:build cff' to the top of this file"
 		for _, f := range file.Flows {
@@ -282,7 +282,7 @@ func (f *flow) mustSetNoOutputProvider(key *function, value int) {
 	}
 }
 
-// addPreciateOutput creates a unique predicate sentinel type. Since CFF's
+// addPreciateOutput creates a unique predicate sentinel type. Since cff's
 // dependency resolution logic only allows for one of each type to be provided
 // to the dependency graph and cff.Predicate functions return booleans,
 // these sentinel types distinguish the outputs of cff.Predicates.
@@ -507,7 +507,7 @@ func (c *compiler) validateFuncs(f *flow) {
 
 	// A list of predicateOutput types are not pushed into the queue as they
 	// are an internal book-keeping type not declared as an input or output
-	// by CFF's public APIs.
+	// by cff's public APIs.
 
 	for queue.Len() > 0 {
 		t := queue.Remove(queue.Front()).(validateVisitedType)
@@ -906,7 +906,7 @@ type predicate struct {
 
 	// SentinelOutput is the sentinel value which represents the boolean
 	// output of the predicate and is used to distinguish the results of the
-	// predicate in the CFF graph.
+	// predicate in the cff graph.
 	SentinelOutput *predicateOutput
 
 	// Serial is a unique serially incrementing number for each predicate.

--- a/internal/compile_test.go
+++ b/internal/compile_test.go
@@ -35,16 +35,16 @@ func TestNoOutputTypes(t *testing.T) {
 	assert.Equal(t, task.invokeType, f.providers.At(task.invokeType))
 }
 
-// toCompile contains a CFF source file, compiler, and Package that the source
+// toCompile contains a cff source file, compiler, and Package that the source
 // file can be compiled with. This assortment is a convenience for invoking the
-// CFF compiler in test.
+// cff compiler in test.
 type toCompile struct {
 	file     *ast.File
 	compiler *compiler
 	pkg      *pkg.Package
 }
 
-// setupCompilers loads a collection of CFF source files and compilers for
+// setupCompilers loads a collection of cff source files and compilers for
 // the source files that can be used to invoke and test compiler behaviour.
 func setupCompilers(
 	t *testing.T,
@@ -105,7 +105,7 @@ func newPackage(p *packages.Package) *pkg.Package {
 	}
 }
 
-// TestCompileFile_Predicate tests that the internal state of the CFF compiler
+// TestCompileFile_Predicate tests that the internal state of the cff compiler
 // is correct after compiling cff.Predicates.
 func TestCompileFile_Predicate(t *testing.T) {
 	cffModule := packagestest.Module{

--- a/internal/compile_tests/parallel/parallel.go
+++ b/internal/compile_tests/parallel/parallel.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ExampleParallel provides a flow that deploys multiple calls to cff.Parallel
-// This flow is compiled to test the CFF compiler's internal state.
+// This flow is compiled to test the cff compiler's internal state.
 func ExampleParallel(m *sync.Map, c chan<- string) error {
 	sendFn := func() {
 		c <- "send"

--- a/internal/compile_tests/predicate/predicate.go
+++ b/internal/compile_tests/predicate/predicate.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ExampleFlowWithPredicates provides a flow that deploys multiple
-// cff.Predicates. This flow is compiled to test the CFF compiler's
+// cff.Predicates. This flow is compiled to test the cff compiler's
 // internal state.
 func ExampleFlowWithPredicates(f func(), pred bool) error {
 	var s string

--- a/internal/directives.go
+++ b/internal/directives.go
@@ -1,6 +1,6 @@
 package internal
 
-// List of functions in the CFF package that are code generation directives.
+// List of functions in the cff package that are code generation directives.
 var _codegenDirectives = map[string]struct{}{
 	"Params":             {},
 	"Results":            {},
@@ -24,7 +24,7 @@ var _codegenDirectives = map[string]struct{}{
 }
 
 // IsCodegenDirective reports whether the function with the given name in the
-// CFF package is a code generation directive.
+// cff package is a code generation directive.
 func IsCodegenDirective(name string) bool {
 	_, ok := _codegenDirectives[name]
 	return ok

--- a/internal/failing_tests/bad-inputs/cff-flow-arguments.go
+++ b/internal/failing_tests/bad-inputs/cff-flow-arguments.go
@@ -30,8 +30,8 @@ func FlowArgumentCallExpression() {
 	)
 }
 
-// FlowArgumentNonCFF is a function that has the wrong arguments to cff.Flow.
-func FlowArgumentNonCFF() {
+// FlowArgumentNonCff is a function that has the wrong arguments to cff.Flow.
+func FlowArgumentNonCff() {
 	badProvider := struct{ ProvidesBad func() cff.Option }{ProvidesBad: func() cff.Option { return cff.Params() }}
 	cff.Flow(context.Background(),
 		badProvider.ProvidesBad(),

--- a/internal/failing_tests/bad-inputs/cff-task-arguments.go
+++ b/internal/failing_tests/bad-inputs/cff-task-arguments.go
@@ -18,7 +18,7 @@ func ExpectsFunctionCallExpression() {
 
 // ExpectedFlowArgumentsSelectorExpression is a function that calls cff.Task with the wrong arguments but trickily
 // passes the type checks.
-// TODO: note doesn't trigger due to string being present in ExpectedFlowArgumentsNotCFF. Leaving for
+// TODO: note doesn't trigger due to string being present in ExpectedFlowArgumentsNotCff. Leaving for
 // illustration purposes.
 func ExpectedFlowArgumentsSelectorExpression() {
 	cff.Flow(
@@ -43,9 +43,9 @@ func ExpectedFlowArgumentsCallExpressions() {
 	)
 }
 
-// ExpectedFlowArgumentsNotCFF is a function that calls cff.Task with the wrong arguments but trickily
+// ExpectedFlowArgumentsNotCff is a function that calls cff.Task with the wrong arguments but trickily
 // passes the type checks.
-func ExpectedFlowArgumentsNotCFF() {
+func ExpectedFlowArgumentsNotCff() {
 	badFn := struct{ ProvideBad func() cff.TaskOption }{func() cff.TaskOption { return cff.Instrument("") }}
 	cff.Flow(
 		context.Background(),
@@ -76,8 +76,8 @@ func ExpectedTasksBadCallExpr() {
 	)
 }
 
-// ExpectedTasksBadCallExprNotCFF is a function that calls cff.Task with the wrong arguments.
-func ExpectedTasksBadCallExprNotCFF() {
+// ExpectedTasksBadCallExprNotCff is a function that calls cff.Task with the wrong arguments.
+func ExpectedTasksBadCallExprNotCff() {
 	badFn := struct{ Task func() int }{func() int { return 0 }}
 	cff.Flow(
 		context.Background(),

--- a/internal/failing_tests/bad-inputs/instrument.go
+++ b/internal/failing_tests/bad-inputs/instrument.go
@@ -9,9 +9,9 @@ import (
 	"go.uber.org/cff"
 )
 
-// MissingCFFLoggerAndMetrics is a flow that wants instrumentation but doesn't provide
+// MissingCffLoggerAndMetrics is a flow that wants instrumentation but doesn't provide
 // a cff.Metrics nor cff.Logger.
-func MissingCFFLoggerAndMetrics() {
+func MissingCffLoggerAndMetrics() {
 	cff.Flow(context.Background(),
 		cff.Task(
 			func() error {

--- a/internal/failing_tests/bad-inputs/parallel.go
+++ b/internal/failing_tests/bad-inputs/parallel.go
@@ -61,7 +61,7 @@ func ParallelInvalidReturnMultiple() {
 }
 
 // ParallelInvalidFuncVar is a Parallel task with a function reference that
-// does not comply with CFF's Tasks function validation.
+// does not comply with cff's Tasks function validation.
 func ParallelInvalidFuncVar() {
 	cff.Parallel(
 		context.Background(),

--- a/internal/flag/mode.go
+++ b/internal/flag/mode.go
@@ -6,19 +6,19 @@ import (
 	"fmt"
 )
 
-// Mode specifies the code generation mode for CFF.
+// Mode specifies the code generation mode for cff.
 type Mode uint8
 
 const (
-	// BaseMode generates CFF code without modification.
+	// BaseMode generates cff code without modification.
 	BaseMode Mode = iota + 1
 
-	// SourceMapMode generates CFF code with line directives to remap
+	// SourceMapMode generates cff code with line directives to remap
 	// generated code locations to source.
 	SourceMapMode
 
-	// ModifierMode generates CFF code that preserves all original file line
-	// locations by generating CFF logic into separate modifier
+	// ModifierMode generates cff code that preserves all original file line
+	// locations by generating cff logic into separate modifier
 	// functions.
 	ModifierMode
 )

--- a/internal/flow_modifier.go
+++ b/internal/flow_modifier.go
@@ -124,6 +124,6 @@ func (fm *flowModifier) Expr() ast.Expr {
 
 func (fm *flowModifier) Provides() []ast.Expr {
 	// cff.Flow Root modifier constructs its arguments from all modifiers
-	// associated with it during CFF compilation.
+	// associated with it during cff compilation.
 	return nil
 }

--- a/internal/gen.go
+++ b/internal/gen.go
@@ -110,7 +110,7 @@ func (g *generator) GenerateFile(f *file) error {
 	// Build tags appear before the package clause.
 	// Write those to the output with cff tags inverted.
 	lastOff := posFile.Offset(f.AST.Package)
-	if err := writeInvertedCFFTag(&buff, bs[:lastOff]); err != nil {
+	if err := writeInvertedCffTag(&buff, bs[:lastOff]); err != nil {
 		return err
 	}
 
@@ -120,7 +120,7 @@ func (g *generator) GenerateFile(f *file) error {
 			return err
 		}
 
-		// Generate code for top-level CFF constructs and update the
+		// Generate code for top-level cff constructs and update the
 		// addImports map.
 		if err = gen.generate(
 			genParams{
@@ -199,7 +199,7 @@ func (g *generator) resetMagicTokens(w io.Writer, buff *bytes.Buffer) error {
 
 	// Then we need to re-parse this to search for the magic token and
 	// replace it with the line directives to "reset" the line directives
-	// that point back to the original CFF source.
+	// that point back to the original cff source.
 	// Without these, all the generated code will point to arbitrary and/or
 	// non-existent locations in the original source.
 	fset := token.NewFileSet()
@@ -227,7 +227,7 @@ func (g *generator) resetMagicTokens(w io.Writer, buff *bytes.Buffer) error {
 	return nil
 }
 
-// generateFlow runs the CFF template for the given flow and writes it to w, modifying addImports if the template
+// generateFlow runs the cff template for the given flow and writes it to w, modifying addImports if the template
 // requires additional imports to be added.
 func (g *generator) generateFlow(file *file, f *flow, w io.Writer, addImports map[string]string, aliases map[string]struct{}) error {
 	// Tracks user-provided expressions used in the generated code.
@@ -458,7 +458,7 @@ func paramExprs(provided map[ast.Expr]struct{}) []ast.Expr {
 
 	for expr := range provided {
 		// A user provided expr cannot have a 0 Line nor 0 Column, so filter
-		// these non user provided entries out. CFF implied instrumentation
+		// these non user provided entries out. cff implied instrumentation
 		// creates expressions that are not user provided and must be handled.
 		if !expr.Pos().IsValid() {
 			continue
@@ -528,10 +528,10 @@ type genParams struct {
 	aliases    map[string]struct{}
 }
 
-// directiveGenerator generates code for top-level CFF constructs.
+// directiveGenerator generates code for top-level cff constructs.
 type directiveGenerator interface {
 	ast.Node
-	// generate produces CFF code with side effects.
+	// generate produces cff code with side effects.
 	generate(p genParams) error
 }
 

--- a/internal/gen2.go
+++ b/internal/gen2.go
@@ -79,7 +79,7 @@ func (g *generatorv2) GenerateFile(f *file) error {
 	// Build tags appear before the package clause.
 	// Write those to the output with cff tags inverted.
 	lastOff := posFile.Offset(f.AST.Package)
-	if err := writeInvertedCFFTag(&buff, bs[:lastOff]); err != nil {
+	if err := writeInvertedCffTag(&buff, bs[:lastOff]); err != nil {
 		return err
 	}
 

--- a/internal/gendirectives/main.go
+++ b/internal/gendirectives/main.go
@@ -5,9 +5,9 @@
 //	func IsCodegenDirective(name string) bool
 //
 // The function returns true if the function with the provided name should be
-// considered a code generation directive by CFF.
+// considered a code generation directive by cff.
 //
-// Code generation directives are defined in cff.go in the root of the CFF
+// Code generation directives are defined in cff.go in the root of the cff
 // project.
 package main
 
@@ -18,7 +18,6 @@ import (
 	"go/token"
 	"log"
 	"os"
-
 	"text/template"
 )
 
@@ -74,7 +73,7 @@ type templateData struct {
 var _tmpl = template.Must(template.New("directives.go").Parse(`
 package internal
 
-// List of functions in the CFF package that are code generation directives.
+// List of functions in the cff package that are code generation directives.
 var _codegenDirectives = map[string]struct{}{
 	{{ range .Directives -}}
 		{{ printf "%q" . }}: {},
@@ -82,7 +81,7 @@ var _codegenDirectives = map[string]struct{}{
 }
 
 // IsCodegenDirective reports whether the function with the given name in the
-// CFF package is a code generation directive.
+// cff package is a code generation directive.
 func IsCodegenDirective(name string) bool {
 	_, ok := _codegenDirectives[name]
 	return ok

--- a/internal/modifier/factory.go
+++ b/internal/modifier/factory.go
@@ -36,19 +36,19 @@ var _ Modifier = (*funcModifier)(nil)
 
 // Params are the inputs to generating a modifier function.
 type Params struct {
-	// Name prefix that will replace the modified CFF directive in generated
+	// Name prefix that will replace the modified cff directive in generated
 	// code.
 	Name string
 	// Modified is the ast.Expr that is replaced by the modifier.
 	Modified ast.Expr
-	// Provided are arguments of modified CFF directive. These values are the
+	// Provided are arguments of modified cff directive. These values are the
 	// same as the values returned by the replacement modifier function.
 	Provided []ast.Expr
 	Fset     *token.FileSet
 	Info     *types.Info
 }
 
-// NewModifier creates a basic modifier from the arguments of a CFF directive.
+// NewModifier creates a basic modifier from the arguments of a cff directive.
 func NewModifier(p Params) Modifier {
 	return &funcModifier{
 		name:     p.Name,

--- a/internal/process.go
+++ b/internal/process.go
@@ -8,7 +8,7 @@ import (
 	"go.uber.org/cff/internal/pkg"
 )
 
-// Processor processes CFF files.
+// Processor processes cff files.
 type Processor struct {
 	Fset               *token.FileSet
 	InstrumentAllTasks bool
@@ -16,7 +16,7 @@ type Processor struct {
 	RequireBuildTag    bool
 }
 
-// Process processes a single CFF file.
+// Process processes a single cff file.
 func (p *Processor) Process(pkg *pkg.Package, file *ast.File, outputPath string) error {
 	c := newCompiler(compilerOpts{
 		Fset:               p.Fset,

--- a/internal/tests/callers/callflowcaller.go
+++ b/internal/tests/callers/callflowcaller.go
@@ -4,7 +4,7 @@ import (
 	"go.uber.org/cff/internal/tests/sandwich"
 )
 
-// PackageCall exports a function that calls a "sandwich" CFF flow and is used by a unit test.
+// PackageCall exports a function that calls a "sandwich" cff flow and is used by a unit test.
 func PackageCall() (string, string) {
 	return sandwich.CallFlow()
 }

--- a/internal/tests/nested_parent/nested_parent.go
+++ b/internal/tests/nested_parent/nested_parent.go
@@ -13,14 +13,12 @@ import (
 	nestedchild "go.uber.org/cff/internal/tests/nested_child"
 )
 
-// Parent is a CFF flow that uses a nested CFF flow.
+// Parent is a cff flow that uses a nested cff flow.
 func Parent(ctx context.Context, i int) (s string, err error) {
 	err = cff.Flow(ctx,
 		cff.Params(i),
 		cff.Results(&s),
-
 		cff.Task(nestedchild.Itoa),
 	)
-
 	return
 }

--- a/internal/tests/nested_parent/nested_parent_gen.go
+++ b/internal/tests/nested_parent/nested_parent_gen.go
@@ -15,7 +15,7 @@ import (
 	nestedchild "go.uber.org/cff/internal/tests/nested_child"
 )
 
-// Parent is a CFF flow that uses a nested CFF flow.
+// Parent is a cff flow that uses a nested cff flow.
 func Parent(ctx context.Context, i int) (s string, err error) {
 	err = func() (err error) {
 
@@ -25,7 +25,7 @@ func Parent(ctx context.Context, i int) (s string, err error) {
 
 		_20_15 := &s
 
-		_22_12 := nestedchild.Itoa
+		_21_12 := nestedchild.Itoa
 		ctx := _18_17
 		var v1 int = _19_14
 		emitter := cff.NopEmitter()
@@ -75,7 +75,7 @@ func Parent(ctx context.Context, i int) (s string, err error) {
 			}
 		}()
 
-		// go.uber.org/cff/internal/tests/nested_parent/nested_parent.go:22:12
+		// go.uber.org/cff/internal/tests/nested_parent/nested_parent.go:21:12
 		var (
 			v2 string
 		)
@@ -105,7 +105,7 @@ func Parent(ctx context.Context, i int) (s string, err error) {
 
 			defer task0.ran.Store(true)
 
-			v2, err = _22_12(ctx, v1)
+			v2, err = _21_12(ctx, v1)
 
 			if err != nil {
 				taskEmitter.TaskError(ctx, err)
@@ -132,6 +132,5 @@ func Parent(ctx context.Context, i int) (s string, err error) {
 		flowEmitter.FlowSuccess(ctx)
 		return nil
 	}()
-
 	return
 }

--- a/internal/tests/sandwich/flowcaller.go
+++ b/internal/tests/sandwich/flowcaller.go
@@ -1,6 +1,6 @@
 package sandwich
 
-// CallFlow exports a function that calls a CFF flow.
+// CallFlow exports a function that calls a cff flow.
 func CallFlow() (string, string) {
 	s, _ := aFlow()
 	t, _ := bFlow()

--- a/internal/tests/setconcurrency/setconcurrency.go
+++ b/internal/tests/setconcurrency/setconcurrency.go
@@ -17,7 +17,7 @@ import (
 // This must be updated if scheduler.worker is renamed.
 const _workerFunction = "go.uber.org/cff/scheduler.worker"
 
-// NumWorkers runs a CFF flow with the provided concurrency, and reports the
+// NumWorkers runs a cff flow with the provided concurrency, and reports the
 // number of workers from within the flow.
 func NumWorkers(conc int) (int, error) {
 	var numGoroutines int
@@ -38,7 +38,7 @@ func NumWorkers(conc int) (int, error) {
 	return numGoroutines, err
 }
 
-// NumWorkersNoArg runs a CFF flow, and reports the
+// NumWorkersNoArg runs a cff flow, and reports the
 // number of workers from within the flow.
 func NumWorkersNoArg() (int, error) {
 	var numGoroutines int
@@ -84,7 +84,7 @@ func numWorkersStable(n int, tick time.Duration) (int, error) {
 	return numw, nil
 }
 
-// numWorkers reports the number of goroutines currently running the CFF
+// numWorkers reports the number of goroutines currently running the cff
 // scheduler's worker function.
 func numWorkers() (int, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(getStack()))

--- a/internal/tests/setconcurrency/setconcurrency_gen.go
+++ b/internal/tests/setconcurrency/setconcurrency_gen.go
@@ -18,7 +18,7 @@ import (
 // This must be updated if scheduler.worker is renamed.
 const _workerFunction = "go.uber.org/cff/scheduler.worker"
 
-// NumWorkers runs a CFF flow with the provided concurrency, and reports the
+// NumWorkers runs a cff flow with the provided concurrency, and reports the
 // number of workers from within the flow.
 func NumWorkers(conc int) (int, error) {
 	var numGoroutines int
@@ -143,7 +143,7 @@ func NumWorkers(conc int) (int, error) {
 	return numGoroutines, err
 }
 
-// NumWorkersNoArg runs a CFF flow, and reports the
+// NumWorkersNoArg runs a cff flow, and reports the
 // number of workers from within the flow.
 func NumWorkersNoArg() (int, error) {
 	var numGoroutines int
@@ -292,7 +292,7 @@ func numWorkersStable(n int, tick time.Duration) (int, error) {
 	return numw, nil
 }
 
-// numWorkers reports the number of goroutines currently running the CFF
+// numWorkers reports the number of goroutines currently running the cff
 // scheduler's worker function.
 func numWorkers() (int, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(getStack()))

--- a/internal/tests/shadowedvar/param_expr.go
+++ b/internal/tests/shadowedvar/param_expr.go
@@ -28,7 +28,7 @@ func ParamOrder(track *orderCheck) error {
 }
 
 // NilParam verifies that cff.Flow is compilable with a user provided nil.
-// CFF should compile and generate this flow even if no test function
+// cff should compile and generate this flow even if no test function
 // uses it.
 func NilParam() {
 	var res []int

--- a/internal/tests/shadowedvar/param_expr_gen.go
+++ b/internal/tests/shadowedvar/param_expr_gen.go
@@ -142,7 +142,7 @@ func ParamOrder(track *orderCheck) error {
 }
 
 // NilParam verifies that cff.Flow is compilable with a user provided nil.
-// CFF should compile and generate this flow even if no test function
+// cff should compile and generate this flow even if no test function
 // uses it.
 func NilParam() {
 	var res []int

--- a/internal/tests/shadowedvar/shadowedvar.go
+++ b/internal/tests/shadowedvar/shadowedvar.go
@@ -10,7 +10,7 @@ import (
 )
 
 // CtxConflict introduces a variable conflict with ctx to demonstrate that
-// CFF does not shadow variables.
+// cff does not shadow variables.
 func CtxConflict(ctx string) (string, error) {
 	var result string
 	err := cff2.Flow(
@@ -27,7 +27,7 @@ func CtxConflict(ctx string) (string, error) {
 }
 
 // CtxConflictParallel introduces a variable conflict with ctx within cff.Parallel Task
-// to demonstrate that CFF does not shadow variables.
+// to demonstrate that cff does not shadow variables.
 func CtxConflictParallel(ctx string) (string, string, error) {
 	var result1 string
 	var result2 string
@@ -44,7 +44,7 @@ func CtxConflictParallel(ctx string) (string, string, error) {
 }
 
 // CtxConflictSlice introduces a variable conflict with ctx within cff.Slice function
-// to demonstrate that CFF does not shadow variables.
+// to demonstrate that cff does not shadow variables.
 func CtxConflictSlice(ctx string, target []string) error {
 	return cff2.Parallel(
 		context.Background(),
@@ -60,7 +60,7 @@ func CtxConflictSlice(ctx string, target []string) error {
 }
 
 // CtxConflictMap introduces a variable conflict with ctx within cff.Map function
-// to demonstrate that CFF does not shadow variables.
+// to demonstrate that cff does not shadow variables.
 func CtxConflictMap(ctx int, input map[int]int) ([]int, error) {
 	slice := make([]int, len(input))
 	err := cff2.Parallel(

--- a/internal/tests/shadowedvar/shadowedvar_gen.go
+++ b/internal/tests/shadowedvar/shadowedvar_gen.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CtxConflict introduces a variable conflict with ctx to demonstrate that
-// CFF does not shadow variables.
+// cff does not shadow variables.
 func CtxConflict(ctx string) (string, error) {
 	var result string
 	err := func() (err error) {
@@ -136,7 +136,7 @@ func CtxConflict(ctx string) (string, error) {
 }
 
 // CtxConflictParallel introduces a variable conflict with ctx within cff.Parallel Task
-// to demonstrate that CFF does not shadow variables.
+// to demonstrate that cff does not shadow variables.
 func CtxConflictParallel(ctx string) (string, string, error) {
 	var result1 string
 	var result2 string
@@ -291,7 +291,7 @@ func CtxConflictParallel(ctx string) (string, string, error) {
 }
 
 // CtxConflictSlice introduces a variable conflict with ctx within cff.Slice function
-// to demonstrate that CFF does not shadow variables.
+// to demonstrate that cff does not shadow variables.
 func CtxConflictSlice(ctx string, target []string) error {
 	return func() (err error) {
 
@@ -395,7 +395,7 @@ func CtxConflictSlice(ctx string, target []string) error {
 }
 
 // CtxConflictMap introduces a variable conflict with ctx within cff.Map function
-// to demonstrate that CFF does not shadow variables.
+// to demonstrate that cff does not shadow variables.
 func CtxConflictMap(ctx int, input map[int]int) ([]int, error) {
 	slice := make([]int, len(input))
 	err := func() (err error) {

--- a/nop_emitter.go
+++ b/nop_emitter.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// NopEmitter is a CFF emitter that does not do anything.
+// NopEmitter is a cff emitter that does not do anything.
 func NopEmitter() Emitter {
 	// We implement the interface on the pointer receiver to avoid
 	// allocations when the emitter is used. Conversion from pointer to

--- a/scheduler.go
+++ b/scheduler.go
@@ -5,20 +5,20 @@ import (
 	"go.uber.org/cff/scheduler"
 )
 
-// We re-export things here so that users of CFF don't have to add other
+// We re-export things here so that users of cff don't have to add other
 // packages as dependencies to their BUILD.bazel.
 
-// Job is a job prepared to be enqueued to the CFF scheduler.
+// Job is a job prepared to be enqueued to the cff scheduler.
 type Job = scheduler.Job
 
 // AtomicBool is a type-safe means of reading and writing boolean values.
 type AtomicBool = atomic.Bool
 
-// ScheduledJob is a job that has been scheduled for execution with the CFF
+// ScheduledJob is a job that has been scheduled for execution with the cff
 // scheduler.
 type ScheduledJob = scheduler.ScheduledJob
 
-// SchedulerParams configures the CFF scheduler.
+// SchedulerParams configures the cff scheduler.
 type SchedulerParams struct {
 	// Concurrency specifies the number of concurrent workers
 	// used by the scheduler to run jobs.

--- a/scheduler/emitter.go
+++ b/scheduler/emitter.go
@@ -1,11 +1,11 @@
 package scheduler
 
-// Emitter emits the state of the CFF scheduler.
+// Emitter emits the state of the cff scheduler.
 type Emitter interface {
 	Emit(State)
 }
 
-// State describes the status of jobs managed by the CFF scheduler.
+// State describes the status of jobs managed by the cff scheduler.
 type State struct {
 	// Pending is total number of jobs, including jobs being executed and
 	// waiting to be executed.

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -1,4 +1,4 @@
-// Package scheduler implements a runtime scheduler for CFF with support for
+// Package scheduler implements a runtime scheduler for cff with support for
 // interdependent jobs.
 //
 // To use the scheduler, build one with New, providing the desired maximum
@@ -155,7 +155,7 @@ func worker(readyc <-chan *ScheduledJob, donec chan<- jobResult) {
 	exitCleanly = true
 }
 
-// Scheduler schedules jobs for a CFF flow based on their dependencies.
+// Scheduler schedules jobs for a cff flow based on their dependencies.
 type Scheduler struct {
 	// Closed when the Scheduler Loop exits.
 	finishedc chan struct{}


### PR DESCRIPTION
"CFF" doesn't stand for anything, so use "cff" as a word everywhere.

Refs #1