### PR TITLE
godoc: Take a pass over API reference

### DIFF
--- a/directive_type.go
+++ b/directive_type.go
@@ -1,22 +1,26 @@
 package cff
 
-// DirectiveType identifies the type of code generation directive.
+// DirectiveType identifies the type of code generation directive
+// for [Emitter] operations.
 type DirectiveType int
 
 const (
-	// UnknownDirective is an unknown directive.
+	// UnknownDirective is an invalid value for a DirectiveType.
 	UnknownDirective DirectiveType = iota
-	// FlowDirective is a cff.Flow directive.
+
+	// FlowDirective marks a Flow.
 	FlowDirective
-	// ParallelDirective is a cff.Parallel directive.
+
+	// ParallelDirective marks a Parallel.
 	ParallelDirective
 )
 
 // String returns the directive string.
 func (d DirectiveType) String() string {
-	if d == FlowDirective {
+	switch d {
+	case FlowDirective:
 		return "flow"
-	} else if d == ParallelDirective {
+	case ParallelDirective:
 		return "parallel"
 	}
 	return "unknown"

--- a/emitter_stack.go
+++ b/emitter_stack.go
@@ -7,10 +7,10 @@ import (
 
 type emitterStack []Emitter
 
-// EmitterStack allows users to combine multiple Emitters together.
+// EmitterStack combines multiple emitters together into one.
 //
-// Events are sent to the emitters in an unspecified order. Emitters should
-// not assume the ordering of events.
+// Events are sent to the emitters in an unspecified order.
+// Emitters should not assume the ordering of events.
 func EmitterStack(emitters ...Emitter) Emitter {
 	switch len(emitters) {
 	case 0:

--- a/scheduler.go
+++ b/scheduler.go
@@ -9,42 +9,57 @@ import (
 // packages as dependencies to their BUILD.bazel.
 
 // Job is a job prepared to be enqueued to the cff scheduler.
+//
+// This is intended to be used by cff's generated code.
+// Do not use directly.
+// This can change without warning.
 type Job = scheduler.Job
 
 // AtomicBool is a type-safe means of reading and writing boolean values.
+//
+// This is intended to be used by cff's generated code.
+// Do not use directly.
+// This can change without warning.
 type AtomicBool = atomic.Bool
+
+// TODO(abg): For Go 1.19 or newer, we can use sync/atomic.Bool
+// which drops one more dependency for users.
 
 // ScheduledJob is a job that has been scheduled for execution with the cff
 // scheduler.
+//
+// This is intended to be used by cff's generated code.
+// Do not use directly.
+// This can change without warning.
 type ScheduledJob = scheduler.ScheduledJob
 
 // SchedulerParams configures the cff scheduler.
+//
+// This is intended to be used by cff's generated code.
+// Do not use directly.
+// This can change without warning.
 type SchedulerParams struct {
 	// Concurrency specifies the number of concurrent workers
 	// used by the scheduler to run jobs.
-	//
-	// See cff.Concurrency for more details.
 	Concurrency int
 	// Emitter provides an emitter for the scheduler.
-	//
-	// See cff.SchedulerEmitter for more details.
 	Emitter SchedulerEmitter
 	// ContinueOnError when true directs the scheduler to continue running
 	// through job errors.
-	//
-	// See cff.ContinueOnError for more details.
 	ContinueOnError bool
 }
 
-// NewScheduler returns a new Scheduler with a maximum of n workers. Enqueue
-// jobs into the returned scheduler in topological order using the Enqueue
-// method, and wait for results with Wait.
+// NewScheduler starts up a cff scheduler for use by Flow or Parallel.
 //
 //	sched := cff.NewScheduler(..)
 //	j1 := sched.Enqueue(cff.Job{...}
 //	j2 := sched.Enqueue(cff.Job{..., Dependencies: []*cff.ScheduledJob{j1}}
 //	// ...
 //	err := sched.Wait()
+//
+// This is intended to be used by cff's generated code.
+// Do not use directly.
+// This can change without warning.
 func NewScheduler(p SchedulerParams) *scheduler.Scheduler {
 	cfg := scheduler.Config{
 		Concurrency:     p.Concurrency,

--- a/scheduler_export_test.go
+++ b/scheduler_export_test.go
@@ -2,6 +2,7 @@ package cff
 
 import "go.uber.org/cff/scheduler"
 
+// AdaptSchedulerEmitter adapts a cff.SchedulerEmitter to a scheduler.Emitter.
 func AdaptSchedulerEmitter(e SchedulerEmitter) scheduler.Emitter {
 	return adaptSchedulerEmitter(e)
 }


### PR DESCRIPTION
This takes a pass over the API reference for cff,
updating some outdated sections and rewording others
for better flow and understanding.

Some docs specifically only referenced flows,
but now they need to account for flows and parallels.

Further, for things like scheduler.go which only re-exports
APIs for ease in code generation,
document that those components may change their APIs unexpectedly
even if we don't intend to do that.

Depends on #29 
Refs #1