### PR TITLE
docs(get-started): Slightly more demonstrative example

### DIFF
--- a/docs/ex/get-started/flow/api.go
+++ b/docs/ex/get-started/flow/api.go
@@ -5,42 +5,44 @@ import "time"
 // region api-def
 
 type UberAPI interface {
-	DriverByID(string) (*Driver, error)
-	RiderByID(string) (*Rider, error)
-	TripByID(string) (*Trip, error)
+	DriverByID(int) (*Driver, error)
+	RiderByID(int) (*Rider, error)
+	TripByID(int) (*Trip, error)
+	LocationByID(int) (*Location, error)
 }
 
 type Driver struct {
-	ID   string
+	ID   int
 	Name string
+}
+
+type Location struct {
+	ID    int
+	City  string
+	State string
+	// ...
 }
 
 type Rider struct {
-	ID   string
-	Name string
+	ID     int
+	Name   string
+	HomeID int
 }
 
 type Trip struct {
-	ID       string
-	DriverID string
-	RiderID  string
+	ID       int
+	DriverID int
+	RiderID  int
 }
 
 // endregion api-def
 
+var _ UberAPI = (*fakeUberClient)(nil)
+
 // region impl
 type fakeUberClient struct{}
 
-func (*fakeUberClient) TripByID(id string) (*Trip, error) {
-	time.Sleep(200 * time.Millisecond)
-	return &Trip{
-		ID:       id,
-		DriverID: "42",
-		RiderID:  "57",
-	}, nil
-}
-
-func (*fakeUberClient) DriverByID(id string) (*Driver, error) {
+func (*fakeUberClient) DriverByID(id int) (*Driver, error) {
 	time.Sleep(500 * time.Millisecond)
 	return &Driver{
 		ID:   id,
@@ -48,11 +50,29 @@ func (*fakeUberClient) DriverByID(id string) (*Driver, error) {
 	}, nil
 }
 
-func (*fakeUberClient) RiderByID(id string) (*Rider, error) {
+func (*fakeUberClient) LocationByID(id int) (*Location, error) {
+	time.Sleep(200 * time.Millisecond)
+	return &Location{
+		ID:    id,
+		City:  "San Francisco",
+		State: "California",
+	}, nil
+}
+
+func (*fakeUberClient) RiderByID(id int) (*Rider, error) {
 	time.Sleep(300 * time.Millisecond)
 	return &Rider{
 		ID:   id,
 		Name: "Richard Dickson",
+	}, nil
+}
+
+func (*fakeUberClient) TripByID(id int) (*Trip, error) {
+	time.Sleep(150 * time.Millisecond)
+	return &Trip{
+		ID:       id,
+		DriverID: 42,
+		RiderID:  57,
 	}, nil
 }
 

--- a/docs/ex/get-started/flow/main.go
+++ b/docs/ex/get-started/flow/main.go
@@ -18,8 +18,9 @@ var uber UberAPI = new(fakeUberClient)
 
 // region resp-decl
 type Response struct {
-	Rider  string
-	Driver string
+	Rider    string
+	Driver   string
+	HomeCity string
 }
 
 // endregion resp-decl
@@ -37,13 +38,16 @@ func main() {
 	// region flow-start
 	err := cff.Flow(ctx,
 		// endregion flow-start
+		// region flow-dots
+		// ...
+		// endregion flow-dots
 		// region params
 		// region resp-var
-		cff.Params("1234"),
+		cff.Params(12),
 		// endregion params
 		cff.Results(&res),
 		// region get-trip
-		cff.Task(func(tripID string) (*Trip, error) {
+		cff.Task(func(tripID int) (*Trip, error) {
 			// endregion resp-var
 			return uber.TripByID(tripID)
 		}),
@@ -58,13 +62,18 @@ func main() {
 			return uber.RiderByID(trip.RiderID)
 		}),
 		// endregion get-rider
+		// region get-location
+		cff.Task(func(rider *Rider) (*Location, error) {
+			return uber.LocationByID(rider.HomeID)
+		}),
+		// endregion get-location
 		// region last-task
-		// ...
 		// region tail
-		cff.Task(func(r *Rider, d *Driver) *Response {
+		cff.Task(func(r *Rider, d *Driver, home *Location) *Response {
 			return &Response{
-				Driver: d.Name,
-				Rider:  r.Name,
+				Driver:   d.Name,
+				Rider:    r.Name,
+				HomeCity: home.City,
 			}
 		}),
 		// endregion last-task
@@ -73,6 +82,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Println(res.Driver, "drove", res.Rider)
+	fmt.Println(res.Driver, "drove", res.Rider, "who lives in", res.HomeCity)
 	// endregion tail
 }


### PR DESCRIPTION
This changes the get-started tutorial to be slightly more demonstrative
of the value of cff.

It does so by introducing another resource: location,
and adding a call to it when one of the types are available.

So instead of a simple fan out and fan back in,
you get a graph where one of the nodes results in another request,
and then fan back in.

This alone ends up demontsrating the kind of complexity cff handles
concurrently.

<img width="774" alt="image" src="https://user-images.githubusercontent.com/41730/197946199-af8f2eb1-f9a1-4853-b4ce-2bce8532c38f.png">
