### PR TITLE
docs(get-started): Missing `//go:build cff`, clarify error handling

### DIFF
--- a/docs/ex/get-started/flow/main.go
+++ b/docs/ex/get-started/flow/main.go
@@ -1,6 +1,9 @@
+// region directive
 //go:build cff
 
 package main
+
+// endregion directive
 
 import (
 	"context"
@@ -68,7 +71,7 @@ func main() {
 		}),
 		// endregion get-location
 		// region last-task
-		// region tail
+		// region error
 		cff.Task(func(r *Rider, d *Driver, home *Location) *Response {
 			return &Response{
 				Driver:   d.Name,
@@ -78,9 +81,11 @@ func main() {
 		}),
 		// endregion last-task
 	)
+	// region tail
 	if err != nil {
 		log.Fatal(err)
 	}
+	// endregion error
 
 	fmt.Println(res.Driver, "drove", res.Rider, "who lives in", res.HomeCity)
 	// endregion tail

--- a/docs/ex/get-started/flow/main_gen.go
+++ b/docs/ex/get-started/flow/main_gen.go
@@ -1,6 +1,9 @@
+// region directive
 //go:build !cff
 
 package main
+
+// endregion directive
 
 import (
 	"context"
@@ -38,44 +41,44 @@ func main() {
 	// region flow-start
 	err := func() (err error) {
 
-		_39_18 := ctx
+		_42_18 := ctx
 
-		_46_14 := 12
+		_49_14 := 12
 
-		_48_15 := &res
+		_51_15 := &res
 
-		_50_12 := func(tripID int) (*Trip, error) {
+		_53_12 := func(tripID int) (*Trip, error) {
 
 			return uber.TripByID(tripID)
 		}
 
-		_56_12 := func(trip *Trip) (*Driver, error) {
+		_59_12 := func(trip *Trip) (*Driver, error) {
 			return uber.DriverByID(trip.DriverID)
 		}
 
-		_61_12 := func(trip *Trip) (*Rider, error) {
+		_64_12 := func(trip *Trip) (*Rider, error) {
 			return uber.RiderByID(trip.RiderID)
 		}
 
-		_66_12 := func(rider *Rider) (*Location, error) {
+		_69_12 := func(rider *Rider) (*Location, error) {
 			return uber.LocationByID(rider.HomeID)
 		}
 
-		_72_12 := func(r *Rider, d *Driver, home *Location) *Response {
+		_75_12 := func(r *Rider, d *Driver, home *Location) *Response {
 			return &Response{
 				Driver:   d.Name,
 				Rider:    r.Name,
 				HomeCity: home.City,
 			}
 		}
-		ctx := _39_18
-		var v1 int = _46_14
+		ctx := _42_18
+		var v1 int = _49_14
 		emitter := cff.NopEmitter()
 
 		var (
 			flowInfo = &cff.FlowInfo{
 				File:   "go.uber.org/cff/docs/ex/get-started/flow/main.go",
-				Line:   39,
+				Line:   42,
 				Column: 9,
 			}
 			flowEmitter = cff.NopFlowEmitter()
@@ -117,7 +120,7 @@ func main() {
 			}
 		}()
 
-		// go.uber.org/cff/docs/ex/get-started/flow/main.go:50:12
+		// go.uber.org/cff/docs/ex/get-started/flow/main.go:53:12
 		var (
 			v2 *Trip
 		)
@@ -147,7 +150,7 @@ func main() {
 
 			defer task0.ran.Store(true)
 
-			v2, err = _50_12(v1)
+			v2, err = _53_12(v1)
 
 			if err != nil {
 				taskEmitter.TaskError(ctx, err)
@@ -164,7 +167,7 @@ func main() {
 		})
 		tasks = append(tasks, task0)
 
-		// go.uber.org/cff/docs/ex/get-started/flow/main.go:56:12
+		// go.uber.org/cff/docs/ex/get-started/flow/main.go:59:12
 		var (
 			v3 *Driver
 		)
@@ -194,7 +197,7 @@ func main() {
 
 			defer task1.ran.Store(true)
 
-			v3, err = _56_12(v2)
+			v3, err = _59_12(v2)
 
 			if err != nil {
 				taskEmitter.TaskError(ctx, err)
@@ -214,7 +217,7 @@ func main() {
 		})
 		tasks = append(tasks, task1)
 
-		// go.uber.org/cff/docs/ex/get-started/flow/main.go:61:12
+		// go.uber.org/cff/docs/ex/get-started/flow/main.go:64:12
 		var (
 			v4 *Rider
 		)
@@ -244,7 +247,7 @@ func main() {
 
 			defer task2.ran.Store(true)
 
-			v4, err = _61_12(v2)
+			v4, err = _64_12(v2)
 
 			if err != nil {
 				taskEmitter.TaskError(ctx, err)
@@ -264,7 +267,7 @@ func main() {
 		})
 		tasks = append(tasks, task2)
 
-		// go.uber.org/cff/docs/ex/get-started/flow/main.go:66:12
+		// go.uber.org/cff/docs/ex/get-started/flow/main.go:69:12
 		var (
 			v5 *Location
 		)
@@ -294,7 +297,7 @@ func main() {
 
 			defer task3.ran.Store(true)
 
-			v5, err = _66_12(v4)
+			v5, err = _69_12(v4)
 
 			if err != nil {
 				taskEmitter.TaskError(ctx, err)
@@ -314,7 +317,7 @@ func main() {
 		})
 		tasks = append(tasks, task3)
 
-		// go.uber.org/cff/docs/ex/get-started/flow/main.go:72:12
+		// go.uber.org/cff/docs/ex/get-started/flow/main.go:75:12
 		var (
 			v6 *Response
 		)
@@ -344,7 +347,7 @@ func main() {
 
 			defer task4.ran.Store(true)
 
-			v6 = _72_12(v4, v3, v5)
+			v6 = _75_12(v4, v3, v5)
 
 			taskEmitter.TaskSuccess(ctx)
 
@@ -366,14 +369,16 @@ func main() {
 			return err
 		}
 
-		*(_48_15) = v6 // *go.uber.org/cff/docs/ex/get-started/flow.Response
+		*(_51_15) = v6 // *go.uber.org/cff/docs/ex/get-started/flow.Response
 
 		flowEmitter.FlowSuccess(ctx)
 		return nil
 	}()
+	// region tail
 	if err != nil {
 		log.Fatal(err)
 	}
+	// endregion error
 
 	fmt.Println(res.Driver, "drove", res.Rider, "who lives in", res.HomeCity)
 	// endregion tail

--- a/docs/get-started/flow.md
+++ b/docs/get-started/flow.md
@@ -98,13 +98,22 @@ instead of using a real system.
 
 Now let's actually make requests to this interface.
 
-1. In your main.go, instantiate the fake client to send requests to.
+1. Create a `main.go` and put a `//go:build cff` comment at the top it.
+   This is necessary for cff to be able to process this file.
+
+   ```go mdox-exec='region ex/get-started/flow/main.go directive'
+   //go:build cff
+
+   package main
+   ```
+
+2. Elsewhere in the file, instantiate the fake client to send requests to.
 
    ```go mdox-exec='region ex/get-started/flow/main.go fake-client'
    var uber UberAPI = new(fakeUberClient)
    ```
 
-2. In main, set up a `context.Context` with a one second timeout.
+3. Declare a `main()` and set up a `context.Context` with a one second timeout.
    We'll use this in our flow.
 
    ```go mdox-exec='region ex/get-started/flow/main.go main ctx'
@@ -113,7 +122,7 @@ Now let's actually make requests to this interface.
      defer cancel()
    ```
 
-3. Now start a new flow by calling `cff.Flow` with the context.
+4. Now start a new flow by calling `cff.Flow` with the context.
 
    ```go mdox-exec='region ex/get-started/flow/main.go main ctx flow-start'
    func main() {
@@ -122,7 +131,7 @@ Now let's actually make requests to this interface.
      err := cff.Flow(ctx,
    ```
 
-4. Add a task to the flow to retrieve information about the trip.
+5. Add a task to the flow to retrieve information about the trip.
 
    ```go mdox-exec='region ex/get-started/flow/main.go flow-start get-trip'
      err := cff.Flow(ctx,
@@ -131,7 +140,7 @@ Now let's actually make requests to this interface.
        }),
    ```
 
-5. The task we just added expects the trip ID to be present in an integer.
+6. The task we just added expects the trip ID to be present in an integer.
    Let's give it that.
    Add a `cff.Params` call to provide the trip ID for this function.
 
@@ -145,7 +154,7 @@ Now let's actually make requests to this interface.
 
    The order in which this is passed to `cff.Flow` does not matter.
 
-6. With a trip object available, the flow can run other operations.
+7. With a trip object available, the flow can run other operations.
    Add two new tasks that, given a trip,
    will fetch the driver and the rider for that trip respectively.
 
@@ -162,7 +171,7 @@ Now let's actually make requests to this interface.
 
    Again, the order in which these are provided does not matter.
 
-7. One of the tasks we just added fetches information about a rider.
+8. One of the tasks we just added fetches information about a rider.
    Add another task that retrieves the rider's location.
 
    ```go mdox-exec='region ex/get-started/flow/main.go flow-start flow-dots get-location'
@@ -173,7 +182,7 @@ Now let's actually make requests to this interface.
        }),
    ```
 
-8. We now have a few different tasks. Let's bring their results together.
+9. We now have a few different tasks. Let's bring their results together.
    Declare a new `Response` type.
 
    ```go mdox-exec='region ex/get-started/flow/main.go resp-decl'
@@ -184,22 +193,22 @@ Now let's actually make requests to this interface.
    }
    ```
 
-9. Back in the flow, add a new task to build the Response
-   from the outputs of the different tasks.
+10. Back in the flow, add a new task to build the Response
+    from the outputs of the different tasks.
 
-   ```go mdox-exec='region ex/get-started/flow/main.go flow-start flow-dots last-task'
-     err := cff.Flow(ctx,
-       // ...
-       cff.Task(func(r *Rider, d *Driver, home *Location) *Response {
-         return &Response{
-           Driver:   d.Name,
-           Rider:    r.Name,
-           HomeCity: home.City,
-         }
-       }),
-   ```
+    ```go mdox-exec='region ex/get-started/flow/main.go flow-start flow-dots last-task'
+      err := cff.Flow(ctx,
+        // ...
+        cff.Task(func(r *Rider, d *Driver, home *Location) *Response {
+          return &Response{
+            Driver:   d.Name,
+            Rider:    r.Name,
+            HomeCity: home.City,
+          }
+        }),
+    ```
 
-10. Run `go generate`. You'll see an error similar to the following:
+11. Run `go generate`. You'll see an error similar to the following:
 
     ```
     main.go:59:12: unused output type *[..].Response
@@ -209,7 +218,7 @@ Now let's actually make requests to this interface.
     or by a `cff.Results` directive which extracts values from a flow.
     Let's fix this.
 
-11. Declare a new `*Response` variable above the `cff.Flow` call,
+12. Declare a new `*Response` variable above the `cff.Flow` call,
     and use `cff.Results` to pass a reference to it to the flow.
     This tells cff to fill that pointer with a value from the flow.
 
@@ -224,10 +233,11 @@ Now let's actually make requests to this interface.
     As with previous cases--the position of `cff.Results` in the `cff.Flow` call
     does not matter.
 
-12. Finally, handle the error returned by `cff.Flow`
-    and print the response.
+13. Handle the error returned by `cff.Flow`.
+    For the tutorial, we're just exiting the application.
+    In a real application, you should handle this error more gracefully.
 
-    ```go mdox-exec='region ex/get-started/flow/main.go tail'
+    ```go mdox-exec='region ex/get-started/flow/main.go error'
         cff.Task(func(r *Rider, d *Driver, home *Location) *Response {
           return &Response{
             Driver:   d.Name,
@@ -239,18 +249,26 @@ Now let's actually make requests to this interface.
       if err != nil {
         log.Fatal(err)
       }
-
-      fmt.Println(res.Driver, "drove", res.Rider, "who lives in", res.HomeCity)
     ```
 
-13. Finally, run `go generate` again.
+14. Lastly, print the result.
+
+    ```go mdox-exec='region ex/get-started/flow/main.go tail'
+    	if err != nil {
+    		log.Fatal(err)
+    	}
+
+    	fmt.Println(res.Driver, "drove", res.Rider, "who lives in", res.HomeCity)
+    ```
+
+15. Finally, run `go generate` again.
     You should see a message similar to the following.
 
     ```
     Processed 3 files with 0 errors
     ```
 
-14. Run `go run .` to run the program.
+16. Run `go run .` to run the program.
 
     ```
     % go run .


### PR DESCRIPTION
We forgot to specify in the tutorial that you need to add `//go:build cff`
to the top of the file.
Do that.

Secondly, separate the "handle the error" and "print the result" steps
because it's easy to miss that we're handling the error otherwise.
