### PR TITLE
docs(get-started): Suggest optional editor setup

### DIFF
--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -33,4 +33,14 @@ First, set up a project.
    EOF
    ```
 
+::: tip Editor setup
+
+You don't need a fully functional editor to try out cff.
+You can copy the provided snippets into your editor for this tutorial.
+However, if you would prefer to have a working editor even for the tutorial,
+take a detour to [Editor configuration](../editor.md)
+and come back here afterwards.
+
+:::
+
 Now [write your first flow](flow.md).


### PR DESCRIPTION
If users expect their editor to function properly during the tutorial,
we should give them the instructions to have that.

---

<img width="799" alt="image" src="https://user-images.githubusercontent.com/41730/198909652-f532a8b7-96cd-424d-87ab-dd46383a5543.png">
