### PR TITLE
Add a new type of error (PanicError) to throw when a task panics

### DIFF
--- a/docs/ex/get-started/flow/main_gen.go
+++ b/docs/ex/get-started/flow/main_gen.go
@@ -147,7 +147,7 @@ func main() {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -197,7 +197,7 @@ func main() {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -250,7 +250,7 @@ func main() {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -303,7 +303,7 @@ func main() {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -356,7 +356,7 @@ func main() {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/docs/ex/get-started/flow/main_gen.go
+++ b/docs/ex/get-started/flow/main_gen.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -142,9 +143,16 @@ func main() {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -189,9 +197,16 @@ func main() {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -239,9 +254,16 @@ func main() {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -289,9 +311,16 @@ func main() {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -339,9 +368,16 @@ func main() {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/docs/ex/get-started/flow/main_gen.go
+++ b/docs/ex/get-started/flow/main_gen.go
@@ -143,15 +143,11 @@ func main() {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -197,15 +193,11 @@ func main() {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -254,15 +246,11 @@ func main() {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -311,15 +299,11 @@ func main() {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -368,15 +352,11 @@ func main() {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/error.go
+++ b/error.go
@@ -50,8 +50,8 @@ type PanicError struct {
 	Value any
 
 	// Stacktrace contains string of what call stack looks like when the panic happened.
-	// This is automatically generated in cff.NewPanicError(), and panic() should
-	// always be at the top of the call stack.
+	// This is populated by calling runtime/debug.Stack() when a non-nil value is
+	// recovered from a cff-scheduled job.
 	Stacktrace string
 }
 

--- a/error.go
+++ b/error.go
@@ -52,11 +52,11 @@ type PanicError struct {
 	// Stacktrace contains string of what call stack looks like when the panic happened.
 	// This is populated by calling runtime/debug.Stack() when a non-nil value is
 	// recovered from a cff-scheduled job.
-	Stacktrace string
+	Stacktrace []byte
 }
 
 var _ error = (*PanicError)(nil)
 
 func (pe *PanicError) Error() string {
-	return fmt.Sprintf("panic: %v\nstacktrace:\n%s", pe.Value, pe.Stacktrace)
+	return fmt.Sprintf("panic: %v\n%s", pe.Value, pe.Stacktrace)
 }

--- a/error.go
+++ b/error.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cff
+
+import (
+	"fmt"
+)
+
+// PanicError is an error that is thrown when a task panics. It contains the value
+// that is recovered from the panic and the stacktrace of where the panic happened.
+// For example, the following code checks if an error from [Flow] is due to a panic:
+//
+//	var r string
+//	err := cff.Flow(
+//		context.Background(),
+//		cff.Results(&r),
+//		cff.Task(
+//			func() string {
+//				panic("panic")
+//			},
+//		),
+//	)
+//	var panicError *cff.PanicError
+//	if errors.As(err, &panicError) {
+//		// err is from a panic
+//		fmt.Printf("recovered: %s\n", panicError.Value)
+//	} else {
+//		// err is not from a panic
+//	}
+type PanicError struct {
+	// Value contains the value recovered from the panic that caused this error.
+	Value any
+
+	// Stacktrace contains string of what call stack looks like when the panic happened.
+	// This is automatically generated in cff.NewPanicError(), and panic() should
+	// always be at the top of the call stack.
+	Stacktrace string
+}
+
+var _ error = (*PanicError)(nil)
+
+func (pe *PanicError) Error() string {
+	return fmt.Sprintf("panic: %v\nstacktrace:\n%s", pe.Value, pe.Stacktrace)
+}

--- a/examples/magic_gen.go
+++ b/examples/magic_gen.go
@@ -161,7 +161,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -206,7 +206,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -236,7 +236,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		// go.uber.org/cff/examples/magic.go:61:4
 		var p0 bool
 		var p0PanicRecover interface{}
-		var p0PanicStacktrace string
+		var p0PanicStacktrace []byte
 		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
@@ -247,7 +247,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
-					p0PanicStacktrace = string(debug.Stack())
+					p0PanicStacktrace = debug.Stack()
 				}
 			}()
 			p0 = _61_18(v2)
@@ -286,7 +286,6 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
-
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)
@@ -324,7 +323,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		// go.uber.org/cff/examples/magic.go:74:4
 		var p1 bool
 		var p1PanicRecover interface{}
-		var p1PanicStacktrace string
+		var p1PanicStacktrace []byte
 		_ = p1PanicStacktrace // possibly unused.
 		pred2 := new(struct {
 			ran cff.AtomicBool
@@ -335,7 +334,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p1PanicRecover = recovered
-					p1PanicStacktrace = string(debug.Stack())
+					p1PanicStacktrace = debug.Stack()
 				}
 			}()
 			p1 = _74_18(v2)
@@ -371,9 +370,9 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
+				var stacktrace []byte
 				if recovered != nil {
-					stacktrace = string(debug.Stack())
+					stacktrace = debug.Stack()
 				}
 				if recovered == nil && p1PanicRecover != nil {
 					recovered = p1PanicRecover
@@ -437,7 +436,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -490,7 +489,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -583,7 +582,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		/*line magic.go:135:4*/
 		_135_4 := map[string]int{"a": 1, "b": 2, "c": 3}
 
-		/*line magic_gen.go:587*/
+		/*line magic_gen.go:586*/
 		ctx := _84_3
 		emitter := cff.NopEmitter()
 
@@ -662,7 +661,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -706,7 +705,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -750,7 +749,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -788,7 +787,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -816,7 +815,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -844,7 +843,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -868,12 +867,11 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			mapTask12.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: debug.Stack(),
+						}
 					}
 				}()
 
@@ -898,12 +896,11 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			mapTask13.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: debug.Stack(),
+						}
 					}
 				}()
 

--- a/examples/magic_gen.go
+++ b/examples/magic_gen.go
@@ -157,15 +157,11 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -206,15 +202,11 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -441,15 +433,11 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -498,15 +486,11 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -599,7 +583,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		/*line magic.go:135:4*/
 		_135_4 := map[string]int{"a": 1, "b": 2, "c": 3}
 
-		/*line magic_gen.go:603*/
+		/*line magic_gen.go:587*/
 		ctx := _84_3
 		emitter := cff.NopEmitter()
 

--- a/examples/magic_gen.go
+++ b/examples/magic_gen.go
@@ -7,6 +7,7 @@ package example
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -83,7 +84,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			return req.LDAPGroup != "everyone"
 		}
 
-		/*line magic_gen.go:87*/
+		/*line magic_gen.go:88*/
 		ctx := _34_18
 		var v1 *Request = _35_14
 		emitter := cff.NopEmitter()
@@ -156,9 +157,16 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -198,9 +206,16 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -229,6 +244,8 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		// go.uber.org/cff/examples/magic.go:61:4
 		var p0 bool
 		var p0PanicRecover interface{}
+		var p0PanicStacktrace string
+		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
 			run func(context.Context) error
@@ -238,6 +255,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
+					p0PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p0 = _61_18(v2)
@@ -273,8 +291,10 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
+
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
+
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)
@@ -312,6 +332,8 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		// go.uber.org/cff/examples/magic.go:74:4
 		var p1 bool
 		var p1PanicRecover interface{}
+		var p1PanicStacktrace string
+		_ = p1PanicStacktrace // possibly unused.
 		pred2 := new(struct {
 			ran cff.AtomicBool
 			run func(context.Context) error
@@ -321,6 +343,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p1PanicRecover = recovered
+					p1PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p1 = _74_18(v2)
@@ -356,12 +379,20 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered == nil && p1PanicRecover != nil {
 					recovered = p1PanicRecover
+					stacktrace = p1PanicStacktrace
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -410,9 +441,16 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -460,9 +498,16 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -554,7 +599,7 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		/*line magic.go:135:4*/
 		_135_4 := map[string]int{"a": 1, "b": 2, "c": 3}
 
-		/*line magic_gen.go:558*/
+		/*line magic_gen.go:603*/
 		ctx := _84_3
 		emitter := cff.NopEmitter()
 
@@ -629,9 +674,13 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -670,9 +719,13 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -711,9 +764,13 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -747,8 +804,12 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			sliceTask9.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _99_4(ctx, idx, val)
@@ -772,8 +833,12 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			sliceTask10.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _107_4(ctx, val)
@@ -797,8 +862,12 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			sliceTask11.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _115_4(ctx, idx, val)
@@ -821,8 +890,12 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			mapTask12.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 
@@ -847,8 +920,12 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			mapTask13.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 

--- a/examples/magic_gen.go
+++ b/examples/magic_gen.go
@@ -658,13 +658,12 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -703,13 +702,12 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -748,13 +746,12 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -788,12 +785,11 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			sliceTask9.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _99_4(ctx, idx, val)
@@ -817,12 +813,11 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			sliceTask10.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _107_4(ctx, val)
@@ -846,12 +841,11 @@ func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			sliceTask11.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _115_4(ctx, idx, val)

--- a/examples/magic_v2_gen.go
+++ b/examples/magic_v2_gen.go
@@ -288,12 +288,11 @@ func _cffFlowmagicv2_32_9(
 	task0.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -321,12 +320,11 @@ func _cffFlowmagicv2_32_9(
 	task1.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -357,12 +355,11 @@ func _cffFlowmagicv2_32_9(
 	task4.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -394,12 +391,11 @@ func _cffFlowmagicv2_32_9(
 	task5.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -432,12 +428,11 @@ func _cffFlowmagicv2_32_9(
 	task2.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -468,12 +463,11 @@ func _cffFlowmagicv2_32_9(
 	task3.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 

--- a/examples/magic_v2_gen.go
+++ b/examples/magic_v2_gen.go
@@ -6,6 +6,7 @@ package example
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -287,8 +288,12 @@ func _cffFlowmagicv2_32_9(
 	task0.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -316,8 +321,12 @@ func _cffFlowmagicv2_32_9(
 	task1.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -348,8 +357,12 @@ func _cffFlowmagicv2_32_9(
 	task4.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -381,8 +394,12 @@ func _cffFlowmagicv2_32_9(
 	task5.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -415,8 +432,12 @@ func _cffFlowmagicv2_32_9(
 	task2.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -447,8 +468,12 @@ func _cffFlowmagicv2_32_9(
 	task3.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 

--- a/internal/modifier/templates/flow_task.go.tmpl
+++ b/internal/modifier/templates/flow_task.go.tmpl
@@ -16,9 +16,10 @@
 {{ $t }}.run = func(ctx {{ $context }}.Context) (err error) {
 	defer func() {
 		recovered := recover()
-		if recovered != nil {
-			err = {{ import "fmt" }}.Errorf("task panic: %v", recovered)
+		if recovered == nil {
+			return
 		}
+		{{ template "panicError" }}
 	}()
 
 	{{ template "taskResultList" . }}{{ if or .Function.HasError (len .Outputs) }} = {{ end }}{{ expr .Function.Node }}{{ template "callTaskArgs" . }}

--- a/internal/modifier/templates/flow_task.go.tmpl
+++ b/internal/modifier/templates/flow_task.go.tmpl
@@ -16,10 +16,9 @@
 {{ $t }}.run = func(ctx {{ $context }}.Context) (err error) {
 	defer func() {
 		recovered := recover()
-		if recovered == nil {
-			return
+		if recovered != nil {
+			{{ template "panicError" }}
 		}
-		{{ template "panicError" }}
 	}()
 
 	{{ template "taskResultList" . }}{{ if or .Function.HasError (len .Outputs) }} = {{ end }}{{ expr .Function.Node }}{{ template "callTaskArgs" . }}

--- a/internal/modifier/templates/panic_error.go.tmpl
+++ b/internal/modifier/templates/panic_error.go.tmpl
@@ -2,7 +2,7 @@
 {{- $cff := import "go.uber.org/cff" -}}
 err = &{{ $cff }}.PanicError{
     Value:      recovered,
-    Stacktrace: string({{ import "runtime/debug" }}.Stack()),
+    Stacktrace: {{ import "runtime/debug" }}.Stack(),
 }
 {{- end -}}
 

--- a/internal/modifier/templates/panic_error.go.tmpl
+++ b/internal/modifier/templates/panic_error.go.tmpl
@@ -1,0 +1,9 @@
+{{- define "panicError" -}}
+{{- $cff := import "go.uber.org/cff" -}}
+err = &{{ $cff }}.PanicError{
+    Value:      recovered,
+    Stacktrace: string({{ import "runtime/debug" }}.Stack()),
+}
+{{- end -}}
+
+{{- /* vim:set ft=gotexttmpl noet: */ -}}

--- a/internal/templates/flow/predicate.go.tmpl
+++ b/internal/templates/flow/predicate.go.tmpl
@@ -5,14 +5,14 @@
 // {{ .PosInfo.File }}:{{ .PosInfo.Line }}:{{ .PosInfo.Column }}
 var p{{ predHash . }} bool
 var p{{ predHash . }}PanicRecover interface{}
-var p{{ predHash . }}PanicStacktrace string
+var p{{ predHash . }}PanicStacktrace []byte
 _ = p{{ predHash . }}PanicStacktrace  // possibly unused.
 {{ $p }} := new({{ template "predicate" }})
 {{ $p }}.run = func(ctx {{ $context }}.Context) (err error) {
     defer func() {
 	if recovered := recover(); recovered != nil {
 	    p{{ predHash . }}PanicRecover = recovered
-        p{{ predHash . }}PanicStacktrace = string({{ import "runtime/debug" }}.Stack())
+        p{{ predHash . }}PanicStacktrace = {{ import "runtime/debug" }}.Stack()
 	}
     }()
     p{{ predHash . }} = {{ expr .Function.Node }}{{ template "callTaskArgs" . }}

--- a/internal/templates/flow/predicate.go.tmpl
+++ b/internal/templates/flow/predicate.go.tmpl
@@ -5,11 +5,14 @@
 // {{ .PosInfo.File }}:{{ .PosInfo.Line }}:{{ .PosInfo.Column }}
 var p{{ predHash . }} bool
 var p{{ predHash . }}PanicRecover interface{}
+var p{{ predHash . }}PanicStacktrace string
+_ = p{{ predHash . }}PanicStacktrace  // possibly unused.
 {{ $p }} := new({{ template "predicate" }})
 {{ $p }}.run = func(ctx {{ $context }}.Context) (err error) {
     defer func() {
 	if recovered := recover(); recovered != nil {
 	    p{{ predHash . }}PanicRecover = recovered
+        p{{ predHash . }}PanicStacktrace = string({{ import "runtime/debug" }}.Stack())
 	}
     }()
     p{{ predHash . }} = {{ expr .Function.Node }}{{ template "callTaskArgs" . }}

--- a/internal/templates/flow/task.go.tmpl
+++ b/internal/templates/flow/task.go.tmpl
@@ -42,9 +42,18 @@
 
 	defer func() {
 		recovered := recover()
+		{{ if not .FallbackWith -}}
+		var stacktrace string
+		if recovered != nil {
+			stacktrace = string({{ import "runtime/debug" }}.Stack())
+		}
+		{{- end }}
 		{{- if .Predicate }}
 			if recovered == nil && p{{ predHash .Predicate }}PanicRecover != nil {
 				recovered = p{{ predHash .Predicate }}PanicRecover
+				{{ if not .FallbackWith -}}
+				stacktrace = p{{ predHash .Predicate }}PanicStacktrace
+				{{- end }}
 			}
 		{{- end }}
 		if recovered != nil {
@@ -55,7 +64,10 @@
 			{{- end }}{{ if gt (len .FallbackWithResults) 0 }}, {{ end }} nil
 		{{- else -}}
 			taskEmitter.TaskPanic(ctx, recovered)
-			err = {{ import "fmt" }}.Errorf("task panic: %v", recovered)
+			err = &{{ $cff }}.PanicError{
+				Value:      recovered,
+				Stacktrace: stacktrace,
+			}
 		{{- end }}
 		}
 	}()

--- a/internal/templates/flow/task.go.tmpl
+++ b/internal/templates/flow/task.go.tmpl
@@ -42,13 +42,13 @@
 
 	defer func() {
 		recovered := recover()
-		{{ if not .FallbackWith -}}
-		var stacktrace string
-		if recovered != nil {
-			stacktrace = string({{ import "runtime/debug" }}.Stack())
-		}
-		{{- end }}
 		{{- if .Predicate }}
+			{{ if not .FallbackWith -}}
+			var stacktrace string
+			if recovered != nil {
+				stacktrace = string({{ import "runtime/debug" }}.Stack())
+			}
+			{{- end }}
 			if recovered == nil && p{{ predHash .Predicate }}PanicRecover != nil {
 				recovered = p{{ predHash .Predicate }}PanicRecover
 				{{ if not .FallbackWith -}}
@@ -64,10 +64,14 @@
 			{{- end }}{{ if gt (len .FallbackWithResults) 0 }}, {{ end }} nil
 		{{- else -}}
 			taskEmitter.TaskPanic(ctx, recovered)
+			{{ if .Predicate -}}
 			err = &{{ $cff }}.PanicError{
 				Value:      recovered,
 				Stacktrace: stacktrace,
 			}
+			{{- else -}}
+			{{ template "panicError" }}
+			{{- end }}
 		{{- end }}
 		}
 	}()

--- a/internal/templates/flow/task.go.tmpl
+++ b/internal/templates/flow/task.go.tmpl
@@ -44,14 +44,14 @@
 		recovered := recover()
 		{{- if .Predicate }}
 			{{ if not .FallbackWith -}}
-			var stacktrace string
+			var stacktrace []byte
 			if recovered != nil {
-				stacktrace = string({{ import "runtime/debug" }}.Stack())
+				stacktrace = {{ import "runtime/debug" }}.Stack()
 			}
 			{{- end }}
 			if recovered == nil && p{{ predHash .Predicate }}PanicRecover != nil {
 				recovered = p{{ predHash .Predicate }}PanicRecover
-				{{ if not .FallbackWith -}}
+				{{- if not .FallbackWith }}
 				stacktrace = p{{ predHash .Predicate }}PanicStacktrace
 				{{- end }}
 			}

--- a/internal/templates/parallel/map.go.tmpl
+++ b/internal/templates/parallel/map.go.tmpl
@@ -14,10 +14,9 @@ for key, val := range {{ expr .Map }} {
 	{{ $t }}.fn = func(ctx {{ $context }}.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
+			if recovered != nil {
+				{{ template "panicError" }}
 			}
-			{{ template "panicError" }}
 		}()
 
 		{{ if .Function.HasError }} err = {{ end }}{{ template "callMap" . }}

--- a/internal/templates/parallel/map.go.tmpl
+++ b/internal/templates/parallel/map.go.tmpl
@@ -39,10 +39,9 @@ for key, val := range {{ expr .Map }} {
 		Run: func(ctx {{ $context }}.Context) (err error) {
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
+				if recovered != nil {
+					{{ template "panicError" }}
 				}
-				{{ template "panicError" }}
 			}()
 
 			{{ if .HasError }} err = {{ end }} {{ template "callFunc" . }}

--- a/internal/templates/parallel/map.go.tmpl
+++ b/internal/templates/parallel/map.go.tmpl
@@ -14,9 +14,10 @@ for key, val := range {{ expr .Map }} {
 	{{ $t }}.fn = func(ctx {{ $context }}.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = {{ import "fmt" }}.Errorf("panic: %v", recovered)
+			if recovered == nil {
+				return
 			}
+			{{ template "panicError" }}
 		}()
 
 		{{ if .Function.HasError }} err = {{ end }}{{ template "callMap" . }}
@@ -37,9 +38,11 @@ for key, val := range {{ expr .Map }} {
 		Dependencies: {{ $t }}Jobs,
 		Run: func(ctx {{ $context }}.Context) (err error) {
 			defer func() {
-				if recovered := recover(); recovered != nil {
-					err = {{ import "fmt" }}.Errorf("panic: %v", recovered)
+				recovered := recover()
+				if recovered == nil {
+					return
 				}
+				{{ template "panicError" }}
 			}()
 
 			{{ if .HasError }} err = {{ end }} {{ template "callFunc" . }}

--- a/internal/templates/parallel/slice.go.tmpl
+++ b/internal/templates/parallel/slice.go.tmpl
@@ -38,10 +38,9 @@ for {{if .HasIndexParameter}} idx {{else}} _ {{end}}, val := range {{ $t }}Slice
 		Run: func(ctx {{ $context }}.Context) (err error) {
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
+				if recovered != nil {
+					{{ template "panicError" }}
 				}
-				{{ template "panicError" }}
 			}()
 
 			{{ template "callSliceEndFn" . }}

--- a/internal/templates/parallel/slice.go.tmpl
+++ b/internal/templates/parallel/slice.go.tmpl
@@ -17,9 +17,10 @@ for {{if .HasIndexParameter}} idx {{else}} _ {{end}}, val := range {{ $t }}Slice
 	{{ $t }}.fn = func(ctx {{ $context }}.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = {{ import "fmt" }}.Errorf("panic: %v", recovered)
+			if recovered == nil {
+				return
 			}
+			{{ template "panicError" }}
 		}()
 		{{ if .Function.HasError }} err = {{ end }}{{ if .HasIndexParameter }}{{ template "callSlice" . }}{{else}}{{ template "callSliceNoIndex" . }}{{end}}
 		return
@@ -38,9 +39,10 @@ for {{if .HasIndexParameter}} idx {{else}} _ {{end}}, val := range {{ $t }}Slice
 		Run: func(ctx {{ $context }}.Context) (err error) {
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					err = {{ import "fmt" }}.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
 				}
+				{{ template "panicError" }}
 			}()
 
 			{{ template "callSliceEndFn" . }}

--- a/internal/templates/parallel/slice.go.tmpl
+++ b/internal/templates/parallel/slice.go.tmpl
@@ -17,10 +17,9 @@ for {{if .HasIndexParameter}} idx {{else}} _ {{end}}, val := range {{ $t }}Slice
 	{{ $t }}.fn = func(ctx {{ $context }}.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
+			if recovered != nil {
+				{{ template "panicError" }}
 			}
-			{{ template "panicError" }}
 		}()
 		{{ if .Function.HasError }} err = {{ end }}{{ if .HasIndexParameter }}{{ template "callSlice" . }}{{else}}{{ template "callSliceNoIndex" . }}{{end}}
 		return

--- a/internal/templates/parallel/task.go.tmpl
+++ b/internal/templates/parallel/task.go.tmpl
@@ -29,10 +29,11 @@
 
 	defer func() {
 		recovered := recover()
-		if recovered != nil {
-			taskEmitter.TaskPanic(ctx, recovered)
-			err = {{ import "fmt" }}.Errorf("panic: %v", recovered)
+		if recovered == nil {
+			return
 		}
+		taskEmitter.TaskPanic(ctx, recovered)
+		{{ template "panicError" }}
 	}()
 
 	defer {{ $t }}.ran.Store(true)

--- a/internal/templates/parallel/task.go.tmpl
+++ b/internal/templates/parallel/task.go.tmpl
@@ -29,11 +29,10 @@
 
 	defer func() {
 		recovered := recover()
-		if recovered == nil {
-			return
+		if recovered != nil {
+			taskEmitter.TaskPanic(ctx, recovered)
+			{{ template "panicError" }}
 		}
-		taskEmitter.TaskPanic(ctx, recovered)
-		{{ template "panicError" }}
 	}()
 
 	defer {{ $t }}.ran.Store(true)

--- a/internal/templates/shared/panic_error.go.tmpl
+++ b/internal/templates/shared/panic_error.go.tmpl
@@ -2,7 +2,7 @@
 {{- $cff := import "go.uber.org/cff" -}}
 err = &{{ $cff }}.PanicError{
     Value:      recovered,
-    Stacktrace: string({{ import "runtime/debug" }}.Stack()),
+    Stacktrace: {{ import "runtime/debug" }}.Stack(),
 }
 {{- end -}}
 

--- a/internal/templates/shared/panic_error.go.tmpl
+++ b/internal/templates/shared/panic_error.go.tmpl
@@ -1,0 +1,9 @@
+{{- define "panicError" -}}
+{{- $cff := import "go.uber.org/cff" -}}
+err = &{{ $cff }}.PanicError{
+    Value:      recovered,
+    Stacktrace: string({{ import "runtime/debug" }}.Stack()),
+}
+{{- end -}}
+
+{{- /* vim:set ft=gotexttmpl noet: */ -}}

--- a/internal/tests/basic/basic_gen.go
+++ b/internal/tests/basic/basic_gen.go
@@ -117,7 +117,7 @@ func SimpleFlow() (string, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -162,7 +162,7 @@ func SimpleFlow() (string, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -212,7 +212,7 @@ func SimpleFlow() (string, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -265,7 +265,7 @@ func SimpleFlow() (string, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -394,7 +394,7 @@ func NoParamsFlow(ctx context.Context) (io.Reader, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -439,7 +439,7 @@ func NoParamsFlow(ctx context.Context) (io.Reader, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -573,7 +573,7 @@ func SerialFailableFlow(ctx context.Context, f1, f2 func() error) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -623,7 +623,7 @@ func SerialFailableFlow(ctx context.Context, f1, f2 func() error) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -676,7 +676,7 @@ func SerialFailableFlow(ctx context.Context, f1, f2 func() error) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -817,7 +817,7 @@ func ProduceMultiple() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -862,7 +862,7 @@ func ProduceMultiple() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/basic/basic_gen.go
+++ b/internal/tests/basic/basic_gen.go
@@ -113,15 +113,11 @@ func SimpleFlow() (string, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -162,15 +158,11 @@ func SimpleFlow() (string, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -216,15 +208,11 @@ func SimpleFlow() (string, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -273,15 +261,11 @@ func SimpleFlow() (string, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -406,15 +390,11 @@ func NoParamsFlow(ctx context.Context) (io.Reader, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -455,15 +435,11 @@ func NoParamsFlow(ctx context.Context) (io.Reader, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -593,15 +569,11 @@ func SerialFailableFlow(ctx context.Context, f1, f2 func() error) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -647,15 +619,11 @@ func SerialFailableFlow(ctx context.Context, f1, f2 func() error) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -704,15 +672,11 @@ func SerialFailableFlow(ctx context.Context, f1, f2 func() error) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -849,15 +813,11 @@ func ProduceMultiple() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -898,15 +858,11 @@ func ProduceMultiple() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/basic/basic_gen.go
+++ b/internal/tests/basic/basic_gen.go
@@ -6,8 +6,8 @@ package basic
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -113,9 +113,16 @@ func SimpleFlow() (string, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -155,9 +162,16 @@ func SimpleFlow() (string, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -202,9 +216,16 @@ func SimpleFlow() (string, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -252,9 +273,16 @@ func SimpleFlow() (string, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -378,9 +406,16 @@ func NoParamsFlow(ctx context.Context) (io.Reader, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -420,9 +455,16 @@ func NoParamsFlow(ctx context.Context) (io.Reader, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -551,9 +593,16 @@ func SerialFailableFlow(ctx context.Context, f1, f2 func() error) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -598,9 +647,16 @@ func SerialFailableFlow(ctx context.Context, f1, f2 func() error) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -648,9 +704,16 @@ func SerialFailableFlow(ctx context.Context, f1, f2 func() error) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -786,9 +849,16 @@ func ProduceMultiple() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -828,9 +898,16 @@ func ProduceMultiple() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/benchmark/benchmark_gen.go
+++ b/internal/tests/benchmark/benchmark_gen.go
@@ -109,15 +109,11 @@ func Baseline() float64 {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -158,15 +154,11 @@ func Baseline() float64 {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -207,15 +199,11 @@ func Baseline() float64 {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/benchmark/benchmark_gen.go
+++ b/internal/tests/benchmark/benchmark_gen.go
@@ -5,7 +5,7 @@ package benchmark
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -109,9 +109,16 @@ func Baseline() float64 {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -151,9 +158,16 @@ func Baseline() float64 {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -193,9 +207,16 @@ func Baseline() float64 {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/benchmark/benchmark_gen.go
+++ b/internal/tests/benchmark/benchmark_gen.go
@@ -113,7 +113,7 @@ func Baseline() float64 {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -158,7 +158,7 @@ func Baseline() float64 {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -203,7 +203,7 @@ func Baseline() float64 {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/benchmark/benchmark_predicate_gen.go
+++ b/internal/tests/benchmark/benchmark_predicate_gen.go
@@ -127,7 +127,7 @@ func PredicateCombined() float64 {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -172,7 +172,7 @@ func PredicateCombined() float64 {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -304,7 +304,7 @@ func PredicateSplit() float64 {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -326,7 +326,7 @@ func PredicateSplit() float64 {
 		// go.uber.org/cff/internal/tests/benchmark/benchmark_predicate.go:77:4
 		var p0 bool
 		var p0PanicRecover interface{}
-		var p0PanicStacktrace string
+		var p0PanicStacktrace []byte
 		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
@@ -337,7 +337,7 @@ func PredicateSplit() float64 {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
-					p0PanicStacktrace = string(debug.Stack())
+					p0PanicStacktrace = debug.Stack()
 				}
 			}()
 			p0 = _78_5()
@@ -370,9 +370,9 @@ func PredicateSplit() float64 {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
+				var stacktrace []byte
 				if recovered != nil {
-					stacktrace = string(debug.Stack())
+					stacktrace = debug.Stack()
 				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover

--- a/internal/tests/benchmark/benchmark_predicate_gen.go
+++ b/internal/tests/benchmark/benchmark_predicate_gen.go
@@ -123,15 +123,11 @@ func PredicateCombined() float64 {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -172,15 +168,11 @@ func PredicateCombined() float64 {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -308,15 +300,11 @@ func PredicateSplit() float64 {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/benchmark/benchmark_predicate_gen.go
+++ b/internal/tests/benchmark/benchmark_predicate_gen.go
@@ -5,7 +5,7 @@ package benchmark
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -123,9 +123,16 @@ func PredicateCombined() float64 {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -165,9 +172,16 @@ func PredicateCombined() float64 {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -294,9 +308,16 @@ func PredicateSplit() float64 {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -317,6 +338,8 @@ func PredicateSplit() float64 {
 		// go.uber.org/cff/internal/tests/benchmark/benchmark_predicate.go:77:4
 		var p0 bool
 		var p0PanicRecover interface{}
+		var p0PanicStacktrace string
+		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
 			run func(context.Context) error
@@ -326,6 +349,7 @@ func PredicateSplit() float64 {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
+					p0PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p0 = _78_5()
@@ -358,12 +382,20 @@ func PredicateSplit() float64 {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
+					stacktrace = p0PanicStacktrace
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/builtincallexpr/builtincallexpr_gen.go
+++ b/internal/tests/builtincallexpr/builtincallexpr_gen.go
@@ -101,7 +101,7 @@ func Flow(s string, buf io.Writer) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/builtincallexpr/builtincallexpr_gen.go
+++ b/internal/tests/builtincallexpr/builtincallexpr_gen.go
@@ -97,15 +97,11 @@ func Flow(s string, buf io.Writer) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/builtincallexpr/builtincallexpr_gen.go
+++ b/internal/tests/builtincallexpr/builtincallexpr_gen.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -96,9 +97,16 @@ func Flow(s string, buf io.Writer) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/cffintest/cffintest_gen_test.go
+++ b/internal/tests/cffintest/cffintest_gen_test.go
@@ -5,7 +5,7 @@ package cffintest
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"testing"
 	"time"
 
@@ -113,9 +113,13 @@ func TestIsOdd(t *testing.T) {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -154,9 +158,13 @@ func TestIsOdd(t *testing.T) {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -195,9 +203,13 @@ func TestIsOdd(t *testing.T) {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -236,9 +248,13 @@ func TestIsOdd(t *testing.T) {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 

--- a/internal/tests/cffintest/cffintest_gen_test.go
+++ b/internal/tests/cffintest/cffintest_gen_test.go
@@ -117,7 +117,7 @@ func TestIsOdd(t *testing.T) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -161,7 +161,7 @@ func TestIsOdd(t *testing.T) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -205,7 +205,7 @@ func TestIsOdd(t *testing.T) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -249,7 +249,7 @@ func TestIsOdd(t *testing.T) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/cffintest/cffintest_gen_test.go
+++ b/internal/tests/cffintest/cffintest_gen_test.go
@@ -113,13 +113,12 @@ func TestIsOdd(t *testing.T) {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -158,13 +157,12 @@ func TestIsOdd(t *testing.T) {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -203,13 +201,12 @@ func TestIsOdd(t *testing.T) {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -248,13 +245,12 @@ func TestIsOdd(t *testing.T) {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 

--- a/internal/tests/earlyresult/earlyresult_gen.go
+++ b/internal/tests/earlyresult/earlyresult_gen.go
@@ -5,7 +5,7 @@ package earlyresult
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -121,9 +121,16 @@ func EarlyResult(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -163,9 +170,16 @@ func EarlyResult(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -208,9 +222,16 @@ func EarlyResult(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -253,9 +274,16 @@ func EarlyResult(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -296,9 +324,16 @@ func EarlyResult(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -451,9 +486,16 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -493,9 +535,16 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -543,9 +592,16 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -588,9 +644,16 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -638,9 +701,16 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -683,9 +753,16 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -730,9 +807,16 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/earlyresult/earlyresult_gen.go
+++ b/internal/tests/earlyresult/earlyresult_gen.go
@@ -125,7 +125,7 @@ func EarlyResult(ctx context.Context) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -170,7 +170,7 @@ func EarlyResult(ctx context.Context) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -218,7 +218,7 @@ func EarlyResult(ctx context.Context) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -266,7 +266,7 @@ func EarlyResult(ctx context.Context) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -312,7 +312,7 @@ func EarlyResult(ctx context.Context) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -470,7 +470,7 @@ func ConsumesResult() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -515,7 +515,7 @@ func ConsumesResult() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -568,7 +568,7 @@ func ConsumesResult() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -616,7 +616,7 @@ func ConsumesResult() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -669,7 +669,7 @@ func ConsumesResult() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -717,7 +717,7 @@ func ConsumesResult() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -767,7 +767,7 @@ func ConsumesResult() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/earlyresult/earlyresult_gen.go
+++ b/internal/tests/earlyresult/earlyresult_gen.go
@@ -121,15 +121,11 @@ func EarlyResult(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -170,15 +166,11 @@ func EarlyResult(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -222,15 +214,11 @@ func EarlyResult(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -274,15 +262,11 @@ func EarlyResult(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -324,15 +308,11 @@ func EarlyResult(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -486,15 +466,11 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -535,15 +511,11 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -592,15 +564,11 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -644,15 +612,11 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -701,15 +665,11 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -753,15 +713,11 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -807,15 +763,11 @@ func ConsumesResult() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/externalpackage/externalpackage_gen.go
+++ b/internal/tests/externalpackage/externalpackage_gen.go
@@ -98,15 +98,11 @@ func NestedType(ctx context.Context, driverUUID uuid.UUID) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -219,15 +215,11 @@ func ImplicitType(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -268,15 +260,11 @@ func ImplicitType(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/externalpackage/externalpackage_gen.go
+++ b/internal/tests/externalpackage/externalpackage_gen.go
@@ -102,7 +102,7 @@ func NestedType(ctx context.Context, driverUUID uuid.UUID) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -219,7 +219,7 @@ func ImplicitType(ctx context.Context) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -264,7 +264,7 @@ func ImplicitType(ctx context.Context) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/externalpackage/externalpackage_gen.go
+++ b/internal/tests/externalpackage/externalpackage_gen.go
@@ -5,7 +5,7 @@ package externalpackage
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -98,9 +98,16 @@ func NestedType(ctx context.Context, driverUUID uuid.UUID) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -212,9 +219,16 @@ func ImplicitType(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -254,9 +268,16 @@ func ImplicitType(ctx context.Context) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/fallbackwith/fallbackwith_gen.go
+++ b/internal/tests/fallbackwith/fallbackwith_gen.go
@@ -96,6 +96,7 @@ func Serial(e error, r string) (string, error) {
 
 			defer func() {
 				recovered := recover()
+
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)
 					v1, err = _22_23, nil
@@ -210,6 +211,7 @@ func NoOutput() error {
 
 			defer func() {
 				recovered := recover()
+
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)
 					err = nil
@@ -331,6 +333,7 @@ func Panic() (string, error) {
 
 			defer func() {
 				recovered := recover()
+
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)
 					v1, err = _51_23, nil

--- a/internal/tests/fallbackwith/fallbackwith_gen.go
+++ b/internal/tests/fallbackwith/fallbackwith_gen.go
@@ -96,7 +96,6 @@ func Serial(e error, r string) (string, error) {
 
 			defer func() {
 				recovered := recover()
-
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)
 					v1, err = _22_23, nil
@@ -211,7 +210,6 @@ func NoOutput() error {
 
 			defer func() {
 				recovered := recover()
-
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)
 					err = nil
@@ -333,7 +331,6 @@ func Panic() (string, error) {
 
 			defer func() {
 				recovered := recover()
-
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)
 					v1, err = _51_23, nil

--- a/internal/tests/importcollision/import_collision_gen.go
+++ b/internal/tests/importcollision/import_collision_gen.go
@@ -109,7 +109,7 @@ func Flow() (string, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -154,7 +154,7 @@ func Flow() (string, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -199,7 +199,7 @@ func Flow() (string, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -244,7 +244,7 @@ func Flow() (string, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -291,7 +291,7 @@ func Flow() (string, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/importcollision/import_collision_gen.go
+++ b/internal/tests/importcollision/import_collision_gen.go
@@ -5,8 +5,8 @@ package importcollision
 
 import (
 	"context"
-	"fmt"
 	_template "html/template"
+	"runtime/debug"
 	__template "text/template"
 	"time"
 
@@ -105,9 +105,16 @@ func Flow() (string, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff2.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -147,9 +154,16 @@ func Flow() (string, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff2.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -189,9 +203,16 @@ func Flow() (string, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff2.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -231,9 +252,16 @@ func Flow() (string, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff2.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -275,9 +303,16 @@ func Flow() (string, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff2.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/importcollision/import_collision_gen.go
+++ b/internal/tests/importcollision/import_collision_gen.go
@@ -105,15 +105,11 @@ func Flow() (string, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -154,15 +150,11 @@ func Flow() (string, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -203,15 +195,11 @@ func Flow() (string, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -252,15 +240,11 @@ func Flow() (string, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -303,15 +287,11 @@ func Flow() (string, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/importstmt/importstmt_gen.go
+++ b/internal/tests/importstmt/importstmt_gen.go
@@ -101,7 +101,7 @@ func Flow() (int, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/importstmt/importstmt_gen.go
+++ b/internal/tests/importstmt/importstmt_gen.go
@@ -97,15 +97,11 @@ func Flow() (int, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/importstmt/importstmt_gen.go
+++ b/internal/tests/importstmt/importstmt_gen.go
@@ -5,7 +5,7 @@ package importstmt
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -97,9 +97,16 @@ func Flow() (int, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/insidegeneric/producer_gen.go
+++ b/internal/tests/insidegeneric/producer_gen.go
@@ -5,7 +5,7 @@ package insidegeneric
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -103,9 +103,16 @@ func JoinTwo[A, B, C any](
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -150,9 +157,16 @@ func JoinTwo[A, B, C any](
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -197,9 +211,16 @@ func JoinTwo[A, B, C any](
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -317,8 +338,12 @@ func JoinMany[T any](producers ...Producer[T]) ([]T, error) {
 			sliceTask3.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _38_4(ctx, idx, val)

--- a/internal/tests/insidegeneric/producer_gen.go
+++ b/internal/tests/insidegeneric/producer_gen.go
@@ -326,12 +326,11 @@ func JoinMany[T any](producers ...Producer[T]) ([]T, error) {
 			sliceTask3.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _38_4(ctx, idx, val)

--- a/internal/tests/insidegeneric/producer_gen.go
+++ b/internal/tests/insidegeneric/producer_gen.go
@@ -103,15 +103,11 @@ func JoinTwo[A, B, C any](
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -157,15 +153,11 @@ func JoinTwo[A, B, C any](
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -211,15 +203,11 @@ func JoinTwo[A, B, C any](
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/insidegeneric/producer_gen.go
+++ b/internal/tests/insidegeneric/producer_gen.go
@@ -107,7 +107,7 @@ func JoinTwo[A, B, C any](
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -157,7 +157,7 @@ func JoinTwo[A, B, C any](
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -207,7 +207,7 @@ func JoinTwo[A, B, C any](
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -329,7 +329,7 @@ func JoinMany[T any](producers ...Producer[T]) ([]T, error) {
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()

--- a/internal/tests/modifier/collision/file1_gen.go
+++ b/internal/tests/modifier/collision/file1_gen.go
@@ -5,7 +5,7 @@ package collision
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -92,8 +92,12 @@ func _cffFlowfile1_15_9(
 	task0.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 

--- a/internal/tests/modifier/collision/file1_gen.go
+++ b/internal/tests/modifier/collision/file1_gen.go
@@ -92,12 +92,11 @@ func _cffFlowfile1_15_9(
 	task0.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 

--- a/internal/tests/modifier/collision/file2_gen.go
+++ b/internal/tests/modifier/collision/file2_gen.go
@@ -92,12 +92,11 @@ func _cffFlowfile2_15_9(
 	task0.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 

--- a/internal/tests/modifier/collision/file2_gen.go
+++ b/internal/tests/modifier/collision/file2_gen.go
@@ -5,7 +5,7 @@ package collision
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -92,8 +92,12 @@ func _cffFlowfile2_15_9(
 	task0.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 

--- a/internal/tests/modifier/simple/simple_gen.go
+++ b/internal/tests/modifier/simple/simple_gen.go
@@ -5,7 +5,7 @@ package simple
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -205,8 +205,12 @@ func _cffFlowsimple_21_9(
 	task0.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -234,8 +238,12 @@ func _cffFlowsimple_21_9(
 	task1.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -266,8 +274,12 @@ func _cffFlowsimple_21_9(
 	task2.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -298,8 +310,12 @@ func _cffFlowsimple_21_9(
 	task3.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -426,8 +442,12 @@ func _cffFlowsimple_55_9(
 	task4.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -455,8 +475,12 @@ func _cffFlowsimple_55_9(
 	task5.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -487,8 +511,12 @@ func _cffFlowsimple_55_9(
 	task6.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -609,8 +637,12 @@ func _cffFlowsimple_82_9(
 	task7.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -638,8 +670,12 @@ func _cffFlowsimple_82_9(
 	task8.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -670,8 +706,12 @@ func _cffFlowsimple_82_9(
 	task9.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -797,8 +837,12 @@ func _cffFlowsimple_106_9(
 	task10.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -826,8 +870,12 @@ func _cffFlowsimple_106_9(
 	task11.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 
@@ -858,8 +906,12 @@ func _cffFlowsimple_106_9(
 	task12.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered != nil {
-				err = fmt.Errorf("task panic: %v", recovered)
+			if recovered == nil {
+				return
+			}
+			err = &cff.PanicError{
+				Value:      recovered,
+				Stacktrace: string(debug.Stack()),
 			}
 		}()
 

--- a/internal/tests/modifier/simple/simple_gen.go
+++ b/internal/tests/modifier/simple/simple_gen.go
@@ -205,12 +205,11 @@ func _cffFlowsimple_21_9(
 	task0.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -238,12 +237,11 @@ func _cffFlowsimple_21_9(
 	task1.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -274,12 +272,11 @@ func _cffFlowsimple_21_9(
 	task2.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -310,12 +307,11 @@ func _cffFlowsimple_21_9(
 	task3.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -442,12 +438,11 @@ func _cffFlowsimple_55_9(
 	task4.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -475,12 +470,11 @@ func _cffFlowsimple_55_9(
 	task5.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -511,12 +505,11 @@ func _cffFlowsimple_55_9(
 	task6.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -637,12 +630,11 @@ func _cffFlowsimple_82_9(
 	task7.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -670,12 +662,11 @@ func _cffFlowsimple_82_9(
 	task8.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -706,12 +697,11 @@ func _cffFlowsimple_82_9(
 	task9.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -837,12 +827,11 @@ func _cffFlowsimple_106_9(
 	task10.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -870,12 +859,11 @@ func _cffFlowsimple_106_9(
 	task11.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 
@@ -906,12 +894,11 @@ func _cffFlowsimple_106_9(
 	task12.run = func(ctx context.Context) (err error) {
 		defer func() {
 			recovered := recover()
-			if recovered == nil {
-				return
-			}
-			err = &cff.PanicError{
-				Value:      recovered,
-				Stacktrace: string(debug.Stack()),
+			if recovered != nil {
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: debug.Stack(),
+				}
 			}
 		}()
 

--- a/internal/tests/named_imports/named_imports_gen.go
+++ b/internal/tests/named_imports/named_imports_gen.go
@@ -99,7 +99,7 @@ func run(ctx newctx.Context) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cffv2.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/named_imports/named_imports_gen.go
+++ b/internal/tests/named_imports/named_imports_gen.go
@@ -95,15 +95,11 @@ func run(ctx newctx.Context) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cffv2.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/named_imports/named_imports_gen.go
+++ b/internal/tests/named_imports/named_imports_gen.go
@@ -5,7 +5,7 @@ package namedimports
 
 import (
 	newctx "context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	cffv2 "go.uber.org/cff"
@@ -95,9 +95,16 @@ func run(ctx newctx.Context) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cffv2.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/nested_child/nested_child_gen.go
+++ b/internal/tests/nested_child/nested_child_gen.go
@@ -96,15 +96,11 @@ func Itoa(ctx context.Context, i int) (s string, err error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/nested_child/nested_child_gen.go
+++ b/internal/tests/nested_child/nested_child_gen.go
@@ -100,7 +100,7 @@ func Itoa(ctx context.Context, i int) (s string, err error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/nested_child/nested_child_gen.go
+++ b/internal/tests/nested_child/nested_child_gen.go
@@ -5,7 +5,7 @@ package nestedchild
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -96,9 +96,16 @@ func Itoa(ctx context.Context, i int) (s string, err error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/nested_parent/nested_parent_gen.go
+++ b/internal/tests/nested_parent/nested_parent_gen.go
@@ -97,15 +97,11 @@ func Parent(ctx context.Context, i int) (s string, err error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/nested_parent/nested_parent_gen.go
+++ b/internal/tests/nested_parent/nested_parent_gen.go
@@ -5,7 +5,7 @@ package nestedparent
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -97,9 +97,16 @@ func Parent(ctx context.Context, i int) (s string, err error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/nested_parent/nested_parent_gen.go
+++ b/internal/tests/nested_parent/nested_parent_gen.go
@@ -101,7 +101,7 @@ func Parent(ctx context.Context, i int) (s string, err error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/noresults/noresults_gen.go
+++ b/internal/tests/noresults/noresults_gen.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -111,9 +112,16 @@ func (h *H) Swallow(ctx context.Context, req string) (err error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -155,9 +163,16 @@ func (h *H) Swallow(ctx context.Context, req string) (err error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -267,9 +282,16 @@ func (h *H) TripleSwallow(ctx context.Context, req string) (err error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -306,9 +328,16 @@ func (h *H) TripleSwallow(ctx context.Context, req string) (err error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -345,9 +374,16 @@ func (h *H) TripleSwallow(ctx context.Context, req string) (err error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -470,9 +506,16 @@ func UnusedInputInvoke() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -509,9 +552,16 @@ func UnusedInputInvoke() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -556,9 +606,16 @@ func UnusedInputInvoke() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/noresults/noresults_gen.go
+++ b/internal/tests/noresults/noresults_gen.go
@@ -112,15 +112,11 @@ func (h *H) Swallow(ctx context.Context, req string) (err error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -163,15 +159,11 @@ func (h *H) Swallow(ctx context.Context, req string) (err error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -282,15 +274,11 @@ func (h *H) TripleSwallow(ctx context.Context, req string) (err error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -328,15 +316,11 @@ func (h *H) TripleSwallow(ctx context.Context, req string) (err error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -374,15 +358,11 @@ func (h *H) TripleSwallow(ctx context.Context, req string) (err error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -506,15 +486,11 @@ func UnusedInputInvoke() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -552,15 +528,11 @@ func UnusedInputInvoke() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -606,15 +578,11 @@ func UnusedInputInvoke() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/noresults/noresults_gen.go
+++ b/internal/tests/noresults/noresults_gen.go
@@ -116,7 +116,7 @@ func (h *H) Swallow(ctx context.Context, req string) (err error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -163,7 +163,7 @@ func (h *H) Swallow(ctx context.Context, req string) (err error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -278,7 +278,7 @@ func (h *H) TripleSwallow(ctx context.Context, req string) (err error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -320,7 +320,7 @@ func (h *H) TripleSwallow(ctx context.Context, req string) (err error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -362,7 +362,7 @@ func (h *H) TripleSwallow(ctx context.Context, req string) (err error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -490,7 +490,7 @@ func UnusedInputInvoke() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -532,7 +532,7 @@ func UnusedInputInvoke() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -582,7 +582,7 @@ func UnusedInputInvoke() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/panic/panic_gen.go
+++ b/internal/tests/panic/panic_gen.go
@@ -5,7 +5,7 @@ package panic
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -105,9 +105,16 @@ func (p *Panicker) FlowPanicsParallel() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -147,9 +154,16 @@ func (p *Panicker) FlowPanicsParallel() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -189,9 +203,16 @@ func (p *Panicker) FlowPanicsParallel() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -310,9 +331,16 @@ func (p *Panicker) FlowPanicsSerial() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/panic/panic_gen.go
+++ b/internal/tests/panic/panic_gen.go
@@ -105,15 +105,11 @@ func (p *Panicker) FlowPanicsParallel() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -154,15 +150,11 @@ func (p *Panicker) FlowPanicsParallel() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -203,15 +195,11 @@ func (p *Panicker) FlowPanicsParallel() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -331,15 +319,11 @@ func (p *Panicker) FlowPanicsSerial() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/panic/panic_gen.go
+++ b/internal/tests/panic/panic_gen.go
@@ -109,7 +109,7 @@ func (p *Panicker) FlowPanicsParallel() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -154,7 +154,7 @@ func (p *Panicker) FlowPanicsParallel() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -199,7 +199,7 @@ func (p *Panicker) FlowPanicsParallel() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -323,7 +323,7 @@ func (p *Panicker) FlowPanicsSerial() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/panic/panic_test.go
+++ b/internal/tests/panic/panic_test.go
@@ -11,21 +11,23 @@ import (
 func TestCatchesPanicParallel(t *testing.T) {
 	var p Panicker
 	err := p.FlowPanicsParallel()
-	assert.ErrorContains(t, err, "panic: panic\nstacktrace:")
+	assert.ErrorContains(t, err, "panic: panic\ngoroutine")
 	var panicError *cff.PanicError
 	require.ErrorAs(t, err, &panicError, "error returned should be a cff.PanicError")
 	assert.Equal(t, "panic", panicError.Value, "PanicError.Value should be recovered value")
-	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
-	assert.Contains(t, panicError.Stacktrace, ".FlowPanicsParallel.func", "function that panicked should be in the stack")
+	stacktrace := string(panicError.Stacktrace)
+	assert.Contains(t, stacktrace, "panic({", "panic should be included in the stack trace")
+	assert.Contains(t, stacktrace, ".FlowPanicsParallel.func", "function that panicked should be in the stack")
 }
 
 func TestCatchesPanicSerial(t *testing.T) {
 	var p Panicker
 	err := p.FlowPanicsSerial()
-	assert.ErrorContains(t, err, "panic: panic\nstacktrace:")
+	assert.ErrorContains(t, err, "panic: panic\ngoroutine")
 	var panicError *cff.PanicError
 	require.ErrorAs(t, err, &panicError, "error returned should be a cff.PanicError")
 	assert.Equal(t, "panic", panicError.Value, "PanicError.Value should be recovered value")
-	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
-	assert.Contains(t, panicError.Stacktrace, ".FlowPanicsSerial.func", "function that panicked should be in the stack")
+	stacktrace := string(panicError.Stacktrace)
+	assert.Contains(t, stacktrace, "panic({", "panic should be included in the stack trace")
+	assert.Contains(t, stacktrace, ".FlowPanicsSerial.func", "function that panicked should be in the stack")
 }

--- a/internal/tests/panic/panic_test.go
+++ b/internal/tests/panic/panic_test.go
@@ -13,7 +13,7 @@ func TestCatchesPanicParallel(t *testing.T) {
 	err := p.FlowPanicsParallel()
 	assert.ErrorContains(t, err, "panic: panic\nstacktrace:")
 	var panicError *cff.PanicError
-	assert.Equal(t, true, errors.As(err, &panicError), "error returned should be a cff.PanicError")
+	require.ErrorAs(t, err, &panicError, "error returned should be a cff.PanicError")
 	assert.Equal(t, "panic", panicError.Value, "PanicError.Value should be recovered value")
 	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
 	assert.Contains(t, panicError.Stacktrace, ".FlowPanicsParallel.func", "function that panicked should be in the stack")
@@ -22,9 +22,9 @@ func TestCatchesPanicParallel(t *testing.T) {
 func TestCatchesPanicSerial(t *testing.T) {
 	var p Panicker
 	err := p.FlowPanicsSerial()
-	assert.ErrorContains(t, err, "panic: panic\n")
+	assert.ErrorContains(t, err, "panic: panic\nstacktrace:")
 	var panicError *cff.PanicError
-	assert.Equal(t, true, errors.As(err, &panicError), "error returned should be a cff.PanicError")
+	require.ErrorAs(t, err, &panicError, "error returned should be a cff.PanicError")
 	assert.Equal(t, "panic", panicError.Value, "PanicError.Value should be recovered value")
 	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
 	assert.Contains(t, panicError.Stacktrace, ".FlowPanicsSerial.func", "function that panicked should be in the stack")

--- a/internal/tests/panic/panic_test.go
+++ b/internal/tests/panic/panic_test.go
@@ -1,10 +1,10 @@
 package panic
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/cff"
 )
 

--- a/internal/tests/parallel/parallel_gen.go
+++ b/internal/tests/parallel/parallel_gen.go
@@ -107,13 +107,12 @@ func TasksAndTask(m *sync.Map) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -148,13 +147,12 @@ func TasksAndTask(m *sync.Map) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -189,13 +187,12 @@ func TasksAndTask(m *sync.Map) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -305,13 +302,12 @@ func TasksWithError() error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -425,13 +421,12 @@ func TasksWithPanic() error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -548,13 +543,12 @@ func MultipleTasks(c chan<- string) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -589,13 +583,12 @@ func MultipleTasks(c chan<- string) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -710,13 +703,12 @@ func ContextErrorBefore(ctx context.Context, src, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -837,13 +829,12 @@ func ContextErrorInFlight(ctx context.Context, cancel func(), src, target []int)
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -878,13 +869,12 @@ func ContextErrorInFlight(ctx context.Context, cancel func(), src, target []int)
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -919,13 +909,12 @@ func ContextErrorInFlight(ctx context.Context, cancel func(), src, target []int)
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -1035,13 +1024,12 @@ func TaskWithError() error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -1155,13 +1143,12 @@ func TaskWithPanic() error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -1279,13 +1266,12 @@ func MultipleTask(src, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -1320,13 +1306,12 @@ func MultipleTask(src, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -1467,13 +1452,12 @@ func ContinueOnError(src []int, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -1512,13 +1496,12 @@ func ContinueOnError(src []int, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -1553,13 +1536,12 @@ func ContinueOnError(src []int, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -1594,13 +1576,12 @@ func ContinueOnError(src []int, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -1735,13 +1716,12 @@ func ContinueOnErrorBoolExpr(src, target []int, fn func() bool) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -1780,13 +1760,12 @@ func ContinueOnErrorBoolExpr(src, target []int, fn func() bool) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -1821,13 +1800,12 @@ func ContinueOnErrorBoolExpr(src, target []int, fn func() bool) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -1940,13 +1918,12 @@ func ContinueOnErrorCancelled(ctx context.Context, src []int, target []int) erro
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -2070,13 +2047,12 @@ func ContinueOnErrorCancelledDuring(ctx context.Context, cancel func(), src []in
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -2111,13 +2087,12 @@ func ContinueOnErrorCancelledDuring(ctx context.Context, cancel func(), src []in
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -2152,13 +2127,12 @@ func ContinueOnErrorCancelledDuring(ctx context.Context, cancel func(), src []in
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -2273,12 +2247,11 @@ func SliceMultiple(srcA, srcB, targetA, targetB []int) error {
 			sliceTask26.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _299_4(idx, val)
@@ -2302,12 +2275,11 @@ func SliceMultiple(srcA, srcB, targetA, targetB []int) error {
 			sliceTask27.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				_306_4(ctx, idx, val)
@@ -2415,12 +2387,11 @@ func SliceNoIndex(srcA, srcB, targetA, targetB []int) error {
 			sliceTask28.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _320_4(val)
@@ -2444,12 +2415,11 @@ func SliceNoIndex(srcA, srcB, targetA, targetB []int) error {
 			sliceTask29.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				_327_4(ctx, val)
@@ -2553,12 +2523,11 @@ func SliceWrapped(src, target manyInts) error {
 			sliceTask30.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _343_4(idx, val)
@@ -2671,12 +2640,11 @@ func AssignSliceItems(src, target []string, keepgoing bool) error {
 			sliceTask31.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _360_4(idx, val)
@@ -2779,12 +2747,11 @@ func SliceEnd(src []int, sliceFn func(idx, val int) error, sliceEndFn func()) (e
 			sliceTask32.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _383_4(idx, val)
@@ -2907,12 +2874,11 @@ func SliceEndWithErr(src []int, sliceFn func(idx, val int) error, sliceEndFn fun
 			sliceTask33.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _398_4(idx, val)
@@ -3035,12 +3001,11 @@ func SliceEndWithCtx(src []int, sliceFn func(idx, val int) error, sliceEndFn fun
 			sliceTask34.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _413_4(idx, val)
@@ -3163,12 +3128,11 @@ func SliceEndWithCtxAndErr(src []int, sliceFn func(idx, val int) error, sliceEnd
 			sliceTask35.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _428_4(idx, val)
@@ -3437,12 +3401,11 @@ func ForEachMapItem[K comparable, V any](
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 
@@ -3569,12 +3532,11 @@ func ForEachMapItemError[K comparable, V any](
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 
@@ -3702,12 +3664,11 @@ func ForEachMapItemContext[K comparable, V any](
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 

--- a/internal/tests/parallel/parallel_gen.go
+++ b/internal/tests/parallel/parallel_gen.go
@@ -111,7 +111,7 @@ func TasksAndTask(m *sync.Map) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -151,7 +151,7 @@ func TasksAndTask(m *sync.Map) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -191,7 +191,7 @@ func TasksAndTask(m *sync.Map) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -306,7 +306,7 @@ func TasksWithError() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -425,7 +425,7 @@ func TasksWithPanic() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -547,7 +547,7 @@ func MultipleTasks(c chan<- string) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -587,7 +587,7 @@ func MultipleTasks(c chan<- string) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -707,7 +707,7 @@ func ContextErrorBefore(ctx context.Context, src, target []int) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -833,7 +833,7 @@ func ContextErrorInFlight(ctx context.Context, cancel func(), src, target []int)
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -873,7 +873,7 @@ func ContextErrorInFlight(ctx context.Context, cancel func(), src, target []int)
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -913,7 +913,7 @@ func ContextErrorInFlight(ctx context.Context, cancel func(), src, target []int)
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -1028,7 +1028,7 @@ func TaskWithError() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -1147,7 +1147,7 @@ func TaskWithPanic() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -1270,7 +1270,7 @@ func MultipleTask(src, target []int) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -1310,7 +1310,7 @@ func MultipleTask(src, target []int) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -1456,7 +1456,7 @@ func ContinueOnError(src []int, target []int) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -1500,7 +1500,7 @@ func ContinueOnError(src []int, target []int) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -1540,7 +1540,7 @@ func ContinueOnError(src []int, target []int) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -1580,7 +1580,7 @@ func ContinueOnError(src []int, target []int) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -1720,7 +1720,7 @@ func ContinueOnErrorBoolExpr(src, target []int, fn func() bool) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -1764,7 +1764,7 @@ func ContinueOnErrorBoolExpr(src, target []int, fn func() bool) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -1804,7 +1804,7 @@ func ContinueOnErrorBoolExpr(src, target []int, fn func() bool) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -1922,7 +1922,7 @@ func ContinueOnErrorCancelled(ctx context.Context, src []int, target []int) erro
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -2051,7 +2051,7 @@ func ContinueOnErrorCancelledDuring(ctx context.Context, cancel func(), src []in
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -2091,7 +2091,7 @@ func ContinueOnErrorCancelledDuring(ctx context.Context, cancel func(), src []in
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -2131,7 +2131,7 @@ func ContinueOnErrorCancelledDuring(ctx context.Context, cancel func(), src []in
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -2250,7 +2250,7 @@ func SliceMultiple(srcA, srcB, targetA, targetB []int) error {
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -2278,7 +2278,7 @@ func SliceMultiple(srcA, srcB, targetA, targetB []int) error {
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -2390,7 +2390,7 @@ func SliceNoIndex(srcA, srcB, targetA, targetB []int) error {
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -2418,7 +2418,7 @@ func SliceNoIndex(srcA, srcB, targetA, targetB []int) error {
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -2526,7 +2526,7 @@ func SliceWrapped(src, target manyInts) error {
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -2643,7 +2643,7 @@ func AssignSliceItems(src, target []string, keepgoing bool) error {
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -2750,7 +2750,7 @@ func SliceEnd(src []int, sliceFn func(idx, val int) error, sliceEndFn func()) (e
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -2767,12 +2767,11 @@ func SliceEnd(src []int, sliceFn func(idx, val int) error, sliceEndFn func()) (e
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: debug.Stack(),
+						}
 					}
 				}()
 
@@ -2877,7 +2876,7 @@ func SliceEndWithErr(src []int, sliceFn func(idx, val int) error, sliceEndFn fun
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -2894,12 +2893,11 @@ func SliceEndWithErr(src []int, sliceFn func(idx, val int) error, sliceEndFn fun
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: debug.Stack(),
+						}
 					}
 				}()
 
@@ -3004,7 +3002,7 @@ func SliceEndWithCtx(src []int, sliceFn func(idx, val int) error, sliceEndFn fun
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -3021,12 +3019,11 @@ func SliceEndWithCtx(src []int, sliceFn func(idx, val int) error, sliceEndFn fun
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: debug.Stack(),
+						}
 					}
 				}()
 
@@ -3131,7 +3128,7 @@ func SliceEndWithCtxAndErr(src []int, sliceFn func(idx, val int) error, sliceEnd
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -3148,12 +3145,11 @@ func SliceEndWithCtxAndErr(src []int, sliceFn func(idx, val int) error, sliceEnd
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: debug.Stack(),
+						}
 					}
 				}()
 
@@ -3264,12 +3260,11 @@ func AssignMapItems(src map[string]int, keys []string, values []int, keepgoing b
 			mapTask36.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: debug.Stack(),
+						}
 					}
 				}()
 
@@ -3378,12 +3373,11 @@ func ForEachMapItem[K comparable, V any](
 			mapTask37.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: debug.Stack(),
+						}
 					}
 				}()
 
@@ -3404,7 +3398,7 @@ func ForEachMapItem[K comparable, V any](
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -3509,12 +3503,11 @@ func ForEachMapItemError[K comparable, V any](
 			mapTask38.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: debug.Stack(),
+						}
 					}
 				}()
 
@@ -3535,7 +3528,7 @@ func ForEachMapItemError[K comparable, V any](
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -3641,12 +3634,11 @@ func ForEachMapItemContext[K comparable, V any](
 			mapTask39.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff.PanicError{
+							Value:      recovered,
+							Stacktrace: debug.Stack(),
+						}
 					}
 				}()
 
@@ -3667,7 +3659,7 @@ func ForEachMapItemContext[K comparable, V any](
 					if recovered != nil {
 						err = &cff.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()

--- a/internal/tests/parallel/parallel_gen.go
+++ b/internal/tests/parallel/parallel_gen.go
@@ -6,8 +6,8 @@ package parallel
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -107,9 +107,13 @@ func TasksAndTask(m *sync.Map) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -144,9 +148,13 @@ func TasksAndTask(m *sync.Map) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -181,9 +189,13 @@ func TasksAndTask(m *sync.Map) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -293,9 +305,13 @@ func TasksWithError() error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -409,9 +425,13 @@ func TasksWithPanic() error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -528,9 +548,13 @@ func MultipleTasks(c chan<- string) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -565,9 +589,13 @@ func MultipleTasks(c chan<- string) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -682,9 +710,13 @@ func ContextErrorBefore(ctx context.Context, src, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -805,9 +837,13 @@ func ContextErrorInFlight(ctx context.Context, cancel func(), src, target []int)
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -842,9 +878,13 @@ func ContextErrorInFlight(ctx context.Context, cancel func(), src, target []int)
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -879,9 +919,13 @@ func ContextErrorInFlight(ctx context.Context, cancel func(), src, target []int)
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -991,9 +1035,13 @@ func TaskWithError() error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -1107,9 +1155,13 @@ func TaskWithPanic() error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -1227,9 +1279,13 @@ func MultipleTask(src, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -1264,9 +1320,13 @@ func MultipleTask(src, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -1407,9 +1467,13 @@ func ContinueOnError(src []int, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -1448,9 +1512,13 @@ func ContinueOnError(src []int, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -1485,9 +1553,13 @@ func ContinueOnError(src []int, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -1522,9 +1594,13 @@ func ContinueOnError(src []int, target []int) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -1659,9 +1735,13 @@ func ContinueOnErrorBoolExpr(src, target []int, fn func() bool) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -1700,9 +1780,13 @@ func ContinueOnErrorBoolExpr(src, target []int, fn func() bool) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -1737,9 +1821,13 @@ func ContinueOnErrorBoolExpr(src, target []int, fn func() bool) error {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -1852,9 +1940,13 @@ func ContinueOnErrorCancelled(ctx context.Context, src []int, target []int) erro
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -1978,9 +2070,13 @@ func ContinueOnErrorCancelledDuring(ctx context.Context, cancel func(), src []in
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -2015,9 +2111,13 @@ func ContinueOnErrorCancelledDuring(ctx context.Context, cancel func(), src []in
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -2052,9 +2152,13 @@ func ContinueOnErrorCancelledDuring(ctx context.Context, cancel func(), src []in
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -2169,8 +2273,12 @@ func SliceMultiple(srcA, srcB, targetA, targetB []int) error {
 			sliceTask26.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _299_4(idx, val)
@@ -2194,8 +2302,12 @@ func SliceMultiple(srcA, srcB, targetA, targetB []int) error {
 			sliceTask27.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				_306_4(ctx, idx, val)
@@ -2303,8 +2415,12 @@ func SliceNoIndex(srcA, srcB, targetA, targetB []int) error {
 			sliceTask28.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _320_4(val)
@@ -2328,8 +2444,12 @@ func SliceNoIndex(srcA, srcB, targetA, targetB []int) error {
 			sliceTask29.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				_327_4(ctx, val)
@@ -2433,8 +2553,12 @@ func SliceWrapped(src, target manyInts) error {
 			sliceTask30.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _343_4(idx, val)
@@ -2547,8 +2671,12 @@ func AssignSliceItems(src, target []string, keepgoing bool) error {
 			sliceTask31.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _360_4(idx, val)
@@ -2651,8 +2779,12 @@ func SliceEnd(src []int, sliceFn func(idx, val int) error, sliceEndFn func()) (e
 			sliceTask32.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _383_4(idx, val)
@@ -2668,8 +2800,12 @@ func SliceEnd(src []int, sliceFn func(idx, val int) error, sliceEndFn func()) (e
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 
@@ -2771,8 +2907,12 @@ func SliceEndWithErr(src []int, sliceFn func(idx, val int) error, sliceEndFn fun
 			sliceTask33.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _398_4(idx, val)
@@ -2788,8 +2928,12 @@ func SliceEndWithErr(src []int, sliceFn func(idx, val int) error, sliceEndFn fun
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 
@@ -2891,8 +3035,12 @@ func SliceEndWithCtx(src []int, sliceFn func(idx, val int) error, sliceEndFn fun
 			sliceTask34.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _413_4(idx, val)
@@ -2908,8 +3056,12 @@ func SliceEndWithCtx(src []int, sliceFn func(idx, val int) error, sliceEndFn fun
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 
@@ -3011,8 +3163,12 @@ func SliceEndWithCtxAndErr(src []int, sliceFn func(idx, val int) error, sliceEnd
 			sliceTask35.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _428_4(idx, val)
@@ -3028,8 +3184,12 @@ func SliceEndWithCtxAndErr(src []int, sliceFn func(idx, val int) error, sliceEnd
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 
@@ -3140,8 +3300,12 @@ func AssignMapItems(src map[string]int, keys []string, values []int, keepgoing b
 			mapTask36.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 
@@ -3250,8 +3414,12 @@ func ForEachMapItem[K comparable, V any](
 			mapTask37.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 
@@ -3268,8 +3436,13 @@ func ForEachMapItem[K comparable, V any](
 			Dependencies: mapTask37Jobs,
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
-					if recovered := recover(); recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					recovered := recover()
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 
@@ -3373,8 +3546,12 @@ func ForEachMapItemError[K comparable, V any](
 			mapTask38.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 
@@ -3391,8 +3568,13 @@ func ForEachMapItemError[K comparable, V any](
 			Dependencies: mapTask38Jobs,
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
-					if recovered := recover(); recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					recovered := recover()
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 
@@ -3497,8 +3679,12 @@ func ForEachMapItemContext[K comparable, V any](
 			mapTask39.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 
@@ -3515,8 +3701,13 @@ func ForEachMapItemContext[K comparable, V any](
 			Dependencies: mapTask39Jobs,
 			Run: func(ctx context.Context) (err error) {
 				defer func() {
-					if recovered := recover(); recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					recovered := recover()
+					if recovered == nil {
+						return
+					}
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 

--- a/internal/tests/parallel/parallel_test.go
+++ b/internal/tests/parallel/parallel_test.go
@@ -37,7 +37,7 @@ func TestTasksWithPanic(t *testing.T) {
 	assert.Contains(t, err.Error(), "panic: sad times\nstacktrace:")
 	// check that error returned is actually a panic error
 	var panicError *cff.PanicError
-	assert.Equal(t, true, errors.As(err, &panicError), "error returned should be a cff.PanicError")
+	require.ErrorAs(t, err, &panicError, "error returned should be a cff.PanicError")
 	assert.Equal(t, "sad times", panicError.Value, "PanicError.Value should be recovered value")
 	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
 	assert.Contains(t, panicError.Stacktrace, ".TasksWithPanic.func", "function that panicked should be in the stack")
@@ -82,7 +82,7 @@ func TestTaskWithPanic(t *testing.T) {
 	assert.Contains(t, err.Error(), "panic: sad times\nstacktrace:")
 	// check that error returned is actually a panic error
 	var panicError *cff.PanicError
-	assert.Equal(t, true, errors.As(err, &panicError), "error returned should be a cff.PanicError")
+	require.ErrorAs(t, err, &panicError, "error returned should be a cff.PanicError")
 	assert.Equal(t, "sad times", panicError.Value, "PanicError.Value should be recovered value")
 	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
 	assert.Contains(t, panicError.Stacktrace, ".TaskWithPanic.func", "function that panicked should be in the stack")
@@ -217,7 +217,7 @@ func TestSlicePanic(t *testing.T) {
 
 	assert.Contains(t, err.Error(), "panic: sadder times\nstacktrace:")
 	var panicError *cff.PanicError
-	assert.Equal(t, true, errors.As(err, &panicError), "error returned should be a cff.PanicError")
+	require.ErrorAs(t, err, &panicError, "error returned should be a cff.PanicError")
 	assert.Equal(t, "sadder times", panicError.Value, "PanicError.Value should be recovered value")
 	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
 	assert.Contains(t, panicError.Stacktrace, ".AssignSliceItems.func", "function that panicked should be in the stack")

--- a/internal/tests/parallel/parallel_test.go
+++ b/internal/tests/parallel/parallel_test.go
@@ -34,13 +34,14 @@ func TestTasksWithError(t *testing.T) {
 func TestTasksWithPanic(t *testing.T) {
 	err := TasksWithPanic()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "panic: sad times\nstacktrace:")
+	assert.Contains(t, err.Error(), "panic: sad times\ngoroutine")
 	// check that error returned is actually a panic error
 	var panicError *cff.PanicError
 	require.ErrorAs(t, err, &panicError, "error returned should be a cff.PanicError")
 	assert.Equal(t, "sad times", panicError.Value, "PanicError.Value should be recovered value")
-	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
-	assert.Contains(t, panicError.Stacktrace, ".TasksWithPanic.func", "function that panicked should be in the stack")
+	stacktrace := string(panicError.Stacktrace)
+	assert.Contains(t, stacktrace, "panic({", "panic should be included in the stack trace")
+	assert.Contains(t, stacktrace, ".TasksWithPanic.func", "function that panicked should be in the stack")
 }
 
 func TestMultipleTasks(t *testing.T) {
@@ -79,13 +80,14 @@ func TestTaskWithError(t *testing.T) {
 func TestTaskWithPanic(t *testing.T) {
 	err := TaskWithPanic()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "panic: sad times\nstacktrace:")
+	assert.Contains(t, err.Error(), "panic: sad times\ngoroutine")
 	// check that error returned is actually a panic error
 	var panicError *cff.PanicError
 	require.ErrorAs(t, err, &panicError, "error returned should be a cff.PanicError")
 	assert.Equal(t, "sad times", panicError.Value, "PanicError.Value should be recovered value")
-	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
-	assert.Contains(t, panicError.Stacktrace, ".TaskWithPanic.func", "function that panicked should be in the stack")
+	stacktrace := string(panicError.Stacktrace)
+	assert.Contains(t, stacktrace, "panic({", "panic should be included in the stack trace")
+	assert.Contains(t, stacktrace, ".TaskWithPanic.func", "function that panicked should be in the stack")
 }
 
 func TestMultipleTask(t *testing.T) {
@@ -105,7 +107,7 @@ func TestContinueOnError(t *testing.T) {
 
 	// Contains is used instead to verify non-deterministic ordering.
 	assert.Contains(t, err.Error(), "sad times")
-	assert.Contains(t, err.Error(), "panic: sadder times\nstacktrace:")
+	assert.Contains(t, err.Error(), "panic: sadder times\ngoroutine")
 
 	assert.Equal(t, src, target)
 }
@@ -215,12 +217,13 @@ func TestSlicePanic(t *testing.T) {
 	err := AssignSliceItems(src, target, false)
 	require.Error(t, err)
 
-	assert.Contains(t, err.Error(), "panic: sadder times\nstacktrace:")
+	assert.Contains(t, err.Error(), "panic: sadder times\ngoroutine")
 	var panicError *cff.PanicError
 	require.ErrorAs(t, err, &panicError, "error returned should be a cff.PanicError")
 	assert.Equal(t, "sadder times", panicError.Value, "PanicError.Value should be recovered value")
-	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
-	assert.Contains(t, panicError.Stacktrace, ".AssignSliceItems.func", "function that panicked should be in the stack")
+	stacktrace := string(panicError.Stacktrace)
+	assert.Contains(t, stacktrace, "panic({", "panic should be included in the stack trace")
+	assert.Contains(t, stacktrace, ".AssignSliceItems.func", "function that panicked should be in the stack")
 	assert.Equal(t, "panic", target[1])
 }
 
@@ -233,7 +236,7 @@ func TestSliceContinueOnError(t *testing.T) {
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "sad times")
-	assert.Contains(t, err.Error(), "panic: sadder times\nstacktrace:")
+	assert.Contains(t, err.Error(), "panic: sadder times\ngoroutine")
 	assert.Contains(t, err.Error(), "panic({", "panic should be included in the stack trace")
 	assert.Contains(t, err.Error(), ".AssignSliceItems.func", "function that panicked should be in the stack")
 	assert.Equal(t, []string{"copy", "error", "panic", "me"}, target)
@@ -242,7 +245,7 @@ func TestSliceContinueOnError(t *testing.T) {
 func TestSliceEnd(t *testing.T) {
 	var src, target []int
 	errSadTimes := errors.New("sad times")
-	errSadderTimes := errors.New("panic: sadder times\nstacktrace:")
+	errSadderTimes := errors.New("panic: sadder times\ngoroutine")
 	tests := []struct {
 		desc       string
 		sliceEndFn func()
@@ -315,7 +318,7 @@ func TestSliceEnd(t *testing.T) {
 func TestSliceEndWithErr(t *testing.T) {
 	var src, target []int
 	errSadTimes := errors.New("sad times")
-	errSadderTimes := errors.New("panic: sadder times\nstacktrace:")
+	errSadderTimes := errors.New("panic: sadder times\ngoroutine")
 	tests := []struct {
 		desc       string
 		sliceEndFn func() error
@@ -402,7 +405,7 @@ func TestSliceEndWithErr(t *testing.T) {
 func TestSliceEndWithCtx(t *testing.T) {
 	var src, target []int
 	errSadTimes := errors.New("sad times")
-	errSadderTimes := errors.New("panic: sadder times\nstacktrace:")
+	errSadderTimes := errors.New("panic: sadder times\ngoroutine")
 	tests := []struct {
 		desc       string
 		sliceEndFn func(ctx context.Context)
@@ -477,7 +480,7 @@ func TestSliceEndWithCtx(t *testing.T) {
 func TestSliceEndWithCtxAndErr(t *testing.T) {
 	var src, target []int
 	errSadTimes := errors.New("sad times")
-	errSadderTimes := errors.New("panic: sadder times\nstacktrace:")
+	errSadderTimes := errors.New("panic: sadder times\ngoroutine")
 	tests := []struct {
 		desc       string
 		sliceEndFn func(ctx context.Context) error
@@ -581,7 +584,7 @@ func TestMapPanic(t *testing.T) {
 	}
 	err := AssignMapItems(src, nil, nil, false)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "panic: sadder times\nstacktrace:")
+	assert.ErrorContains(t, err, "panic: sadder times\ngoroutine")
 }
 
 func TestMapContinueOnError(t *testing.T) {

--- a/internal/tests/predicate/predicate_gen.go
+++ b/internal/tests/predicate/predicate_gen.go
@@ -5,7 +5,7 @@ package predicate
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -78,6 +78,8 @@ func Simple(f func(), pred bool) error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:24:4
 		var p0 bool
 		var p0PanicRecover interface{}
+		var p0PanicStacktrace string
+		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
 			run func(context.Context) error
@@ -87,6 +89,7 @@ func Simple(f func(), pred bool) error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
+					p0PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p0 = _24_18()
@@ -119,12 +122,20 @@ func Simple(f func(), pred bool) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
+					stacktrace = p0PanicStacktrace
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -232,6 +243,8 @@ func SimpleWithContextTask() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:41:4
 		var p0 bool
 		var p0PanicRecover interface{}
+		var p0PanicStacktrace string
+		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
 			run func(context.Context) error
@@ -241,6 +254,7 @@ func SimpleWithContextTask() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
+					p0PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p0 = _42_5(v2)
@@ -273,12 +287,20 @@ func SimpleWithContextTask() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
+					stacktrace = p0PanicStacktrace
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -386,6 +408,8 @@ func SimpleWithContextPredicate() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:61:4
 		var p0 bool
 		var p0PanicRecover interface{}
+		var p0PanicStacktrace string
+		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
 			run func(context.Context) error
@@ -395,6 +419,7 @@ func SimpleWithContextPredicate() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
+					p0PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p0 = _62_5(ctx, v2)
@@ -427,12 +452,20 @@ func SimpleWithContextPredicate() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
+					stacktrace = p0PanicStacktrace
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -540,6 +573,8 @@ func SimpleWithContextTaskAndPredicate() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:81:4
 		var p0 bool
 		var p0PanicRecover interface{}
+		var p0PanicStacktrace string
+		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
 			run func(context.Context) error
@@ -549,6 +584,7 @@ func SimpleWithContextTaskAndPredicate() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
+					p0PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p0 = _82_5(ctx, v2)
@@ -581,12 +617,20 @@ func SimpleWithContextTaskAndPredicate() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
+					stacktrace = p0PanicStacktrace
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -719,9 +763,16 @@ func ExtraDependencies() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -761,9 +812,16 @@ func ExtraDependencies() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -784,6 +842,8 @@ func ExtraDependencies() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:107:4
 		var p0 bool
 		var p0PanicRecover interface{}
+		var p0PanicStacktrace string
+		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
 			run func(context.Context) error
@@ -793,6 +853,7 @@ func ExtraDependencies() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
+					p0PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p0 = _108_5(v3, v4)
@@ -828,12 +889,20 @@ func ExtraDependencies() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
+					stacktrace = p0PanicStacktrace
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -946,6 +1015,8 @@ func MultiplePredicates() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:128:4
 		var p0 bool
 		var p0PanicRecover interface{}
+		var p0PanicStacktrace string
+		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
 			run func(context.Context) error
@@ -955,6 +1026,7 @@ func MultiplePredicates() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
+					p0PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p0 = _128_18()
@@ -987,12 +1059,20 @@ func MultiplePredicates() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
+					stacktrace = p0PanicStacktrace
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -1020,6 +1100,8 @@ func MultiplePredicates() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:134:4
 		var p1 bool
 		var p1PanicRecover interface{}
+		var p1PanicStacktrace string
+		_ = p1PanicStacktrace // possibly unused.
 		pred2 := new(struct {
 			ran cff.AtomicBool
 			run func(context.Context) error
@@ -1029,6 +1111,7 @@ func MultiplePredicates() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p1PanicRecover = recovered
+					p1PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p1 = _134_18()
@@ -1061,12 +1144,20 @@ func MultiplePredicates() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered == nil && p1PanicRecover != nil {
 					recovered = p1PanicRecover
+					stacktrace = p1PanicStacktrace
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -1172,6 +1263,8 @@ func Panicked() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:149:4
 		var p0 bool
 		var p0PanicRecover interface{}
+		var p0PanicStacktrace string
+		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
 			run func(context.Context) error
@@ -1181,6 +1274,7 @@ func Panicked() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
+					p0PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p0 = _150_5()
@@ -1213,12 +1307,20 @@ func Panicked() error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
+					stacktrace = p0PanicStacktrace
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -1326,6 +1428,8 @@ func PanickedWithFallback() (string, error) {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:170:4
 		var p0 bool
 		var p0PanicRecover interface{}
+		var p0PanicStacktrace string
+		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
 			run func(context.Context) error
@@ -1335,6 +1439,7 @@ func PanickedWithFallback() (string, error) {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
+					p0PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p0 = _171_5()
@@ -1367,8 +1472,10 @@ func PanickedWithFallback() (string, error) {
 
 			defer func() {
 				recovered := recover()
+
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
+
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)

--- a/internal/tests/predicate/predicate_gen.go
+++ b/internal/tests/predicate/predicate_gen.go
@@ -78,7 +78,7 @@ func Simple(f func(), pred bool) error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:24:4
 		var p0 bool
 		var p0PanicRecover interface{}
-		var p0PanicStacktrace string
+		var p0PanicStacktrace []byte
 		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
@@ -89,7 +89,7 @@ func Simple(f func(), pred bool) error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
-					p0PanicStacktrace = string(debug.Stack())
+					p0PanicStacktrace = debug.Stack()
 				}
 			}()
 			p0 = _24_18()
@@ -122,9 +122,9 @@ func Simple(f func(), pred bool) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
+				var stacktrace []byte
 				if recovered != nil {
-					stacktrace = string(debug.Stack())
+					stacktrace = debug.Stack()
 				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
@@ -243,7 +243,7 @@ func SimpleWithContextTask() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:41:4
 		var p0 bool
 		var p0PanicRecover interface{}
-		var p0PanicStacktrace string
+		var p0PanicStacktrace []byte
 		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
@@ -254,7 +254,7 @@ func SimpleWithContextTask() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
-					p0PanicStacktrace = string(debug.Stack())
+					p0PanicStacktrace = debug.Stack()
 				}
 			}()
 			p0 = _42_5(v2)
@@ -287,9 +287,9 @@ func SimpleWithContextTask() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
+				var stacktrace []byte
 				if recovered != nil {
-					stacktrace = string(debug.Stack())
+					stacktrace = debug.Stack()
 				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
@@ -408,7 +408,7 @@ func SimpleWithContextPredicate() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:61:4
 		var p0 bool
 		var p0PanicRecover interface{}
-		var p0PanicStacktrace string
+		var p0PanicStacktrace []byte
 		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
@@ -419,7 +419,7 @@ func SimpleWithContextPredicate() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
-					p0PanicStacktrace = string(debug.Stack())
+					p0PanicStacktrace = debug.Stack()
 				}
 			}()
 			p0 = _62_5(ctx, v2)
@@ -452,9 +452,9 @@ func SimpleWithContextPredicate() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
+				var stacktrace []byte
 				if recovered != nil {
-					stacktrace = string(debug.Stack())
+					stacktrace = debug.Stack()
 				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
@@ -573,7 +573,7 @@ func SimpleWithContextTaskAndPredicate() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:81:4
 		var p0 bool
 		var p0PanicRecover interface{}
-		var p0PanicStacktrace string
+		var p0PanicStacktrace []byte
 		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
@@ -584,7 +584,7 @@ func SimpleWithContextTaskAndPredicate() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
-					p0PanicStacktrace = string(debug.Stack())
+					p0PanicStacktrace = debug.Stack()
 				}
 			}()
 			p0 = _82_5(ctx, v2)
@@ -617,9 +617,9 @@ func SimpleWithContextTaskAndPredicate() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
+				var stacktrace []byte
 				if recovered != nil {
-					stacktrace = string(debug.Stack())
+					stacktrace = debug.Stack()
 				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
@@ -767,7 +767,7 @@ func ExtraDependencies() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -812,7 +812,7 @@ func ExtraDependencies() error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -834,7 +834,7 @@ func ExtraDependencies() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:107:4
 		var p0 bool
 		var p0PanicRecover interface{}
-		var p0PanicStacktrace string
+		var p0PanicStacktrace []byte
 		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
@@ -845,7 +845,7 @@ func ExtraDependencies() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
-					p0PanicStacktrace = string(debug.Stack())
+					p0PanicStacktrace = debug.Stack()
 				}
 			}()
 			p0 = _108_5(v3, v4)
@@ -881,9 +881,9 @@ func ExtraDependencies() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
+				var stacktrace []byte
 				if recovered != nil {
-					stacktrace = string(debug.Stack())
+					stacktrace = debug.Stack()
 				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
@@ -1007,7 +1007,7 @@ func MultiplePredicates() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:128:4
 		var p0 bool
 		var p0PanicRecover interface{}
-		var p0PanicStacktrace string
+		var p0PanicStacktrace []byte
 		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
@@ -1018,7 +1018,7 @@ func MultiplePredicates() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
-					p0PanicStacktrace = string(debug.Stack())
+					p0PanicStacktrace = debug.Stack()
 				}
 			}()
 			p0 = _128_18()
@@ -1051,9 +1051,9 @@ func MultiplePredicates() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
+				var stacktrace []byte
 				if recovered != nil {
-					stacktrace = string(debug.Stack())
+					stacktrace = debug.Stack()
 				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
@@ -1092,7 +1092,7 @@ func MultiplePredicates() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:134:4
 		var p1 bool
 		var p1PanicRecover interface{}
-		var p1PanicStacktrace string
+		var p1PanicStacktrace []byte
 		_ = p1PanicStacktrace // possibly unused.
 		pred2 := new(struct {
 			ran cff.AtomicBool
@@ -1103,7 +1103,7 @@ func MultiplePredicates() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p1PanicRecover = recovered
-					p1PanicStacktrace = string(debug.Stack())
+					p1PanicStacktrace = debug.Stack()
 				}
 			}()
 			p1 = _134_18()
@@ -1136,9 +1136,9 @@ func MultiplePredicates() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
+				var stacktrace []byte
 				if recovered != nil {
-					stacktrace = string(debug.Stack())
+					stacktrace = debug.Stack()
 				}
 				if recovered == nil && p1PanicRecover != nil {
 					recovered = p1PanicRecover
@@ -1255,7 +1255,7 @@ func Panicked() error {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:149:4
 		var p0 bool
 		var p0PanicRecover interface{}
-		var p0PanicStacktrace string
+		var p0PanicStacktrace []byte
 		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
@@ -1266,7 +1266,7 @@ func Panicked() error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
-					p0PanicStacktrace = string(debug.Stack())
+					p0PanicStacktrace = debug.Stack()
 				}
 			}()
 			p0 = _150_5()
@@ -1299,9 +1299,9 @@ func Panicked() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
+				var stacktrace []byte
 				if recovered != nil {
-					stacktrace = string(debug.Stack())
+					stacktrace = debug.Stack()
 				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
@@ -1420,7 +1420,7 @@ func PanickedWithFallback() (string, error) {
 		// go.uber.org/cff/internal/tests/predicate/predicate.go:170:4
 		var p0 bool
 		var p0PanicRecover interface{}
-		var p0PanicStacktrace string
+		var p0PanicStacktrace []byte
 		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff.AtomicBool
@@ -1431,7 +1431,7 @@ func PanickedWithFallback() (string, error) {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
-					p0PanicStacktrace = string(debug.Stack())
+					p0PanicStacktrace = debug.Stack()
 				}
 			}()
 			p0 = _171_5()
@@ -1467,7 +1467,6 @@ func PanickedWithFallback() (string, error) {
 
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
-
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)

--- a/internal/tests/predicate/predicate_gen.go
+++ b/internal/tests/predicate/predicate_gen.go
@@ -763,15 +763,11 @@ func ExtraDependencies() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -812,15 +808,11 @@ func ExtraDependencies() error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/predicate/predicate_test.go
+++ b/internal/tests/predicate/predicate_test.go
@@ -54,7 +54,7 @@ func TestPanicRecovered(t *testing.T) {
 		},
 	)
 	var panicError *cff.PanicError
-	assert.Equal(t, true, errors.As(err, &panicError), "error returned should be a cff.PanicError")
+	require.ErrorAs(t, err, &panicError, "error returned should be a cff.PanicError")
 	assert.Equal(t, "sad times", panicError.Value, "PanicError.Value should be recovered value")
 	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
 	assert.Contains(t, panicError.Stacktrace, ".Panicked.func", "function that panicked should be in the stack")

--- a/internal/tests/predicate/predicate_test.go
+++ b/internal/tests/predicate/predicate_test.go
@@ -1,7 +1,6 @@
 package predicate
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/internal/tests/predicate/predicate_test.go
+++ b/internal/tests/predicate/predicate_test.go
@@ -55,8 +55,9 @@ func TestPanicRecovered(t *testing.T) {
 	var panicError *cff.PanicError
 	require.ErrorAs(t, err, &panicError, "error returned should be a cff.PanicError")
 	assert.Equal(t, "sad times", panicError.Value, "PanicError.Value should be recovered value")
-	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
-	assert.Contains(t, panicError.Stacktrace, ".Panicked.func", "function that panicked should be in the stack")
+	stacktrace := string(panicError.Stacktrace)
+	assert.Contains(t, stacktrace, "panic({", "panic should be included in the stack trace")
+	assert.Contains(t, stacktrace, ".Panicked.func", "function that panicked should be in the stack")
 }
 
 func TestPanicFallback(t *testing.T) {

--- a/internal/tests/predicate/predicate_test.go
+++ b/internal/tests/predicate/predicate_test.go
@@ -1,10 +1,12 @@
 package predicate
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/cff"
 )
 
 func TestSimplePredicate(t *testing.T) {
@@ -51,7 +53,11 @@ func TestPanicRecovered(t *testing.T) {
 			err = Panicked()
 		},
 	)
-	assert.EqualError(t, err, "task panic: sad times")
+	var panicError *cff.PanicError
+	assert.Equal(t, true, errors.As(err, &panicError), "error returned should be a cff.PanicError")
+	assert.Equal(t, "sad times", panicError.Value, "PanicError.Value should be recovered value")
+	assert.Contains(t, panicError.Stacktrace, "panic({", "panic should be included in the stack trace")
+	assert.Contains(t, panicError.Stacktrace, ".Panicked.func", "function that panicked should be in the stack")
 }
 
 func TestPanicFallback(t *testing.T) {

--- a/internal/tests/sandwich/aflow_gen.go
+++ b/internal/tests/sandwich/aflow_gen.go
@@ -89,15 +89,11 @@ func aFlow() (s string, err error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/sandwich/aflow_gen.go
+++ b/internal/tests/sandwich/aflow_gen.go
@@ -93,7 +93,7 @@ func aFlow() (s string, err error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/sandwich/aflow_gen.go
+++ b/internal/tests/sandwich/aflow_gen.go
@@ -5,7 +5,7 @@ package sandwich
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -89,9 +89,16 @@ func aFlow() (s string, err error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/sandwich/bflow_gen.go
+++ b/internal/tests/sandwich/bflow_gen.go
@@ -93,7 +93,7 @@ func bFlow() (s string, err error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/sandwich/bflow_gen.go
+++ b/internal/tests/sandwich/bflow_gen.go
@@ -89,15 +89,11 @@ func bFlow() (s string, err error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/sandwich/bflow_gen.go
+++ b/internal/tests/sandwich/bflow_gen.go
@@ -5,7 +5,7 @@ package sandwich
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	"go.uber.org/cff"
@@ -89,9 +89,16 @@ func bFlow() (s string, err error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/setconcurrency/setconcurrency_gen.go
+++ b/internal/tests/setconcurrency/setconcurrency_gen.go
@@ -104,15 +104,11 @@ func NumWorkers(conc int) (int, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -234,15 +230,11 @@ func NumWorkersNoArg() (int, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/setconcurrency/setconcurrency_gen.go
+++ b/internal/tests/setconcurrency/setconcurrency_gen.go
@@ -7,8 +7,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"fmt"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -104,9 +104,16 @@ func NumWorkers(conc int) (int, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -227,9 +234,16 @@ func NumWorkersNoArg() (int, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/setconcurrency/setconcurrency_gen.go
+++ b/internal/tests/setconcurrency/setconcurrency_gen.go
@@ -108,7 +108,7 @@ func NumWorkers(conc int) (int, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -234,7 +234,7 @@ func NumWorkersNoArg() (int, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/shadowedvar/param_expr_gen.go
+++ b/internal/tests/shadowedvar/param_expr_gen.go
@@ -5,7 +5,7 @@ package shadowedvar
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"testing"
 	"time"
 
@@ -104,9 +104,16 @@ func ParamOrder(track *orderCheck) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -231,6 +238,7 @@ func NilParam() {
 
 			defer func() {
 				recovered := recover()
+
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)
 					v4, err = nil, nil

--- a/internal/tests/shadowedvar/param_expr_gen.go
+++ b/internal/tests/shadowedvar/param_expr_gen.go
@@ -104,15 +104,11 @@ func ParamOrder(track *orderCheck) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()
@@ -238,7 +234,6 @@ func NilParam() {
 
 			defer func() {
 				recovered := recover()
-
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)
 					v4, err = nil, nil

--- a/internal/tests/shadowedvar/param_expr_gen.go
+++ b/internal/tests/shadowedvar/param_expr_gen.go
@@ -108,7 +108,7 @@ func ParamOrder(track *orderCheck) error {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()

--- a/internal/tests/shadowedvar/shadowedvar_gen.go
+++ b/internal/tests/shadowedvar/shadowedvar_gen.go
@@ -5,7 +5,7 @@ package shadowedvar
 
 import (
 	"context"
-	"fmt"
+	"runtime/debug"
 	"time"
 
 	cff2 "go.uber.org/cff"
@@ -96,9 +96,16 @@ func CtxConflict(ctx string) (string, error) {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff2.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 
@@ -224,9 +231,13 @@ func CtxConflictParallel(ctx string) (string, string, error) {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff2.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -261,9 +272,13 @@ func CtxConflictParallel(ctx string) (string, string, error) {
 
 			defer func() {
 				recovered := recover()
-				if recovered != nil {
-					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("panic: %v", recovered)
+				if recovered == nil {
+					return
+				}
+				taskEmitter.TaskPanic(ctx, recovered)
+				err = &cff2.PanicError{
+					Value:      recovered,
+					Stacktrace: string(debug.Stack()),
 				}
 			}()
 
@@ -373,8 +388,12 @@ func CtxConflictSlice(ctx string, target []string) error {
 			sliceTask3.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff2.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 				err = _53_4(idx, val)
@@ -476,8 +495,12 @@ func CtxConflictMap(ctx int, input map[int]int) ([]int, error) {
 			mapTask4.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered != nil {
-						err = fmt.Errorf("panic: %v", recovered)
+					if recovered == nil {
+						return
+					}
+					err = &cff2.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
 					}
 				}()
 
@@ -568,6 +591,8 @@ func PredicateCtxConflict(f func(), ctx bool) error {
 		// go.uber.org/cff/internal/tests/shadowedvar/shadowedvar.go:92:4
 		var p0 bool
 		var p0PanicRecover interface{}
+		var p0PanicStacktrace string
+		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff2.AtomicBool
 			run func(context.Context) error
@@ -577,6 +602,7 @@ func PredicateCtxConflict(f func(), ctx bool) error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
+					p0PanicStacktrace = string(debug.Stack())
 				}
 			}()
 			p0 = _92_19()
@@ -609,12 +635,20 @@ func PredicateCtxConflict(f func(), ctx bool) error {
 
 			defer func() {
 				recovered := recover()
+				var stacktrace string
+				if recovered != nil {
+					stacktrace = string(debug.Stack())
+				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover
+					stacktrace = p0PanicStacktrace
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
-					err = fmt.Errorf("task panic: %v", recovered)
+					err = &cff2.PanicError{
+						Value:      recovered,
+						Stacktrace: stacktrace,
+					}
 				}
 			}()
 

--- a/internal/tests/shadowedvar/shadowedvar_gen.go
+++ b/internal/tests/shadowedvar/shadowedvar_gen.go
@@ -96,15 +96,11 @@ func CtxConflict(ctx string) (string, error) {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
-				if recovered != nil {
-					stacktrace = string(debug.Stack())
-				}
 				if recovered != nil {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: stacktrace,
+						Stacktrace: string(debug.Stack()),
 					}
 				}
 			}()

--- a/internal/tests/shadowedvar/shadowedvar_gen.go
+++ b/internal/tests/shadowedvar/shadowedvar_gen.go
@@ -100,7 +100,7 @@ func CtxConflict(ctx string) (string, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -231,7 +231,7 @@ func CtxConflictParallel(ctx string) (string, string, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -271,7 +271,7 @@ func CtxConflictParallel(ctx string) (string, string, error) {
 					taskEmitter.TaskPanic(ctx, recovered)
 					err = &cff2.PanicError{
 						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+						Stacktrace: debug.Stack(),
 					}
 				}
 			}()
@@ -385,7 +385,7 @@ func CtxConflictSlice(ctx string, target []string) error {
 					if recovered != nil {
 						err = &cff2.PanicError{
 							Value:      recovered,
-							Stacktrace: string(debug.Stack()),
+							Stacktrace: debug.Stack(),
 						}
 					}
 				}()
@@ -488,12 +488,11 @@ func CtxConflictMap(ctx int, input map[int]int) ([]int, error) {
 			mapTask4.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff2.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff2.PanicError{
+							Value:      recovered,
+							Stacktrace: debug.Stack(),
+						}
 					}
 				}()
 
@@ -584,7 +583,7 @@ func PredicateCtxConflict(f func(), ctx bool) error {
 		// go.uber.org/cff/internal/tests/shadowedvar/shadowedvar.go:92:4
 		var p0 bool
 		var p0PanicRecover interface{}
-		var p0PanicStacktrace string
+		var p0PanicStacktrace []byte
 		_ = p0PanicStacktrace // possibly unused.
 		pred1 := new(struct {
 			ran cff2.AtomicBool
@@ -595,7 +594,7 @@ func PredicateCtxConflict(f func(), ctx bool) error {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					p0PanicRecover = recovered
-					p0PanicStacktrace = string(debug.Stack())
+					p0PanicStacktrace = debug.Stack()
 				}
 			}()
 			p0 = _92_19()
@@ -628,9 +627,9 @@ func PredicateCtxConflict(f func(), ctx bool) error {
 
 			defer func() {
 				recovered := recover()
-				var stacktrace string
+				var stacktrace []byte
 				if recovered != nil {
-					stacktrace = string(debug.Stack())
+					stacktrace = debug.Stack()
 				}
 				if recovered == nil && p0PanicRecover != nil {
 					recovered = p0PanicRecover

--- a/internal/tests/shadowedvar/shadowedvar_gen.go
+++ b/internal/tests/shadowedvar/shadowedvar_gen.go
@@ -227,13 +227,12 @@ func CtxConflictParallel(ctx string) (string, string, error) {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff2.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff2.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -268,13 +267,12 @@ func CtxConflictParallel(ctx string) (string, string, error) {
 
 			defer func() {
 				recovered := recover()
-				if recovered == nil {
-					return
-				}
-				taskEmitter.TaskPanic(ctx, recovered)
-				err = &cff2.PanicError{
-					Value:      recovered,
-					Stacktrace: string(debug.Stack()),
+				if recovered != nil {
+					taskEmitter.TaskPanic(ctx, recovered)
+					err = &cff2.PanicError{
+						Value:      recovered,
+						Stacktrace: string(debug.Stack()),
+					}
 				}
 			}()
 
@@ -384,12 +382,11 @@ func CtxConflictSlice(ctx string, target []string) error {
 			sliceTask3.fn = func(ctx context.Context) (err error) {
 				defer func() {
 					recovered := recover()
-					if recovered == nil {
-						return
-					}
-					err = &cff2.PanicError{
-						Value:      recovered,
-						Stacktrace: string(debug.Stack()),
+					if recovered != nil {
+						err = &cff2.PanicError{
+							Value:      recovered,
+							Stacktrace: string(debug.Stack()),
+						}
 					}
 				}()
 				err = _53_4(idx, val)


### PR DESCRIPTION
This PR adds a new type of custom error, `PanicError`, which gets thrown when a task panics. 
`PanicError` contains the value recovered from the panic and a stack trace, similar to what gets 
printed when a panic occurs. With this, users can determine if an error was due to a panic or 
something else, and act upon that information however they choose.
Fixes #25 