### PR TITLE
ci(docs): Fix branch trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
   # This lets us publish the workflow
   # manually from the GitHub Actions UI.


### PR DESCRIPTION
The trigger is using master,
but this repository uses a main branch.