### PR TITLE
chore(docs/ex): Mark generated files

### DIFF
--- a/docs/ex/.gitattributes
+++ b/docs/ex/.gitattributes
@@ -1,0 +1,2 @@
+# Mark cff-generated files generated.
+**/*_gen.go linguist-generated=true


### PR DESCRIPTION
Marks files generated by cff as "linguist-generated".
This makes GitHub skip the diffs by default.
We already have such a file in examples/ and testdata.
