### PR TITLE
ci: Fix broken main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-latest"]
         go: ["1.18.x", "1.19.x"]
         include:
         - go: 1.19.x

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ feel free to [start a new discussion](https://github.com/uber-go/cff/discussions
 instead and we'll assist you if we can.
 
 ## Contributing Code
+
 Before contributing code, please follow [these steps](#contributing-ideas).
 
 When your feature is accepted by maintainers, follow these steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ feel free to [start a new discussion](https://github.com/uber-go/cff/discussions
 instead and we'll assist you if we can.
 
 ## Contributing Code
-Before contributing code, please follow [these steps](#new-functionality).
+Before contributing code, please follow [these steps](#contributing-ideas).
 
 When your feature is accepted by maintainers, follow these steps:
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
-export GOBIN = $(shell pwd)/bin
+SHELL = /bin/bash
+
+# Cross-platform way to find the directory holding this Makefile.
+PROJECT_ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+export GOBIN = $(PROJECT_ROOT)/bin
 export PATH := $(GOBIN):$(PATH)
 
 MODULES ?= . ./examples ./internal/tests ./tools ./docs
 TEST_FLAGS ?= -race
 
-CFF = $(GOBIN)/cff
-MOCKGEN = $(GOBIN)/mockgen
-STATICCHECK = $(GOBIN)/staticcheck
-MDOX = $(GOBIN)/mdox
+CFF = bin/cff
+MOCKGEN = bin/mockgen
+STATICCHECK = bin/staticcheck
+MDOX = bin/mdox
 
 # 'make cover' should not run on docs by default.
 # We run that separately explicitly on a specific platform.

--- a/docs/.mdox-validate.yaml
+++ b/docs/.mdox-validate.yaml
@@ -8,3 +8,7 @@ validators:
     type: 'githubPullsIssues'
   - regex: '(^http[s]?:\/\/)(www\.)?(github\.com\/)uber-go\/cff(\/discussions\/)'
     type: 'ignore'
+
+  # Ignore pkg.go.dev links until release.
+  - regex: '(^http[s]?:\/\/)(pkg\.)?(go\.dev\/)'
+    type: 'ignore'

--- a/docs/get-started/flow.md
+++ b/docs/get-started/flow.md
@@ -261,7 +261,6 @@ Now let's actually make requests to this interface.
     	fmt.Println(res.Driver, "drove", res.Rider, "who lives in", res.HomeCity)
     ```
 
-
 15. Finally, run `go generate` again.
     You should see a message similar to the following.
 


### PR DESCRIPTION
CI on main is currently broken for several reasons:

- The Makefile wasn't Windows friendly.
- Some of the documentation had broken links.
- Some of the documentation was poorly formatted.
- Windows support is broken.

All but the last issue has been fixed by this PR.
We're dropping Windows support for now.
Two follow-ups were created: #53, #54 