### PR TITLE
lint: Use golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,27 +8,28 @@ on:
 
 jobs:
 
-  # Checks that the generated code is up-to-date.
-  # Runs in parallel with the other job that runs tests.
-  check-generated:
-    name: Check generated code
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Go
-      uses: actions/setup-go@v4
+    - uses: actions/checkout@v4
+      name: Check out repository
+    - uses: actions/setup-go@v4
+      name: Set up Go
       with:
         go-version: 1.21.x
+        cache: false  # managed by golangci-lint
 
-    - name: Download Dependencies
-      run: go mod download
+    - uses: golangci/golangci-lint-action@v3
+      name: Install golangci-lint
+      with:
+        version: latest
+        args: --version  # make lint will run the linter
 
+    # Verify that all generated code is up-to-date.
     - name: Regenerate code
       run: make generate
-
     - name: Verify unchanged
       run: |
         if ! git diff --quiet; then
@@ -36,6 +37,9 @@ jobs:
           git diff
           exit 1
         fi
+
+    - run: make lint
+      name: Lint
 
   build-test:
     name: Build and test
@@ -45,10 +49,6 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         go: ["1.20.x", "1.21.x"]
-        include:
-        - go: 1.21.x
-          os: "ubuntu-latest"
-          latest: true
 
     steps:
     - name: Checkout code
@@ -61,10 +61,6 @@ jobs:
 
     - name: Download Dependencies
       run: go mod download
-
-    - name: Lint
-      run: make lint
-      if: matrix.latest
 
     - name: Test
       run: make cover

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,53 @@
+output:
+  # Make output more digestible with quickfix in vim/emacs/etc.
+  sort-results: true
+  print-issued-lines: false
+
+linters:
+  # We'll track the golangci-lint default linters manually
+  # instead of letting them change without our control.
+  disable-all: true
+  enable:
+    # golangci-lint defaults:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+    # Our own extras:
+    - gofmt
+    - nolintlint # lints nolint directives
+    - revive
+
+linters-settings:
+  govet:
+    # These govet checks are disabled by default, but they're useful.
+    enable:
+      - niliness
+      - reflectvaluecompare
+      - sortslice
+      - unusedwrite
+
+issues:
+  # Print all issues reported by all linters.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+  # Don't ignore some of the issues that golangci-lint considers okay.
+  # This includes documenting all exported entities.
+  exclude-use-default: false
+
+  exclude-rules:
+    # Don't warn on unused parameters.
+    # Parameter names are useful; replacing them with '_' is undesirable.
+    - linters: [revive]
+      text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
+
+    # staticcheck already has smarter checks for empty blocks.
+    # revive's empty-block linter has false positives.
+    # For example, as of writing this, the following is not allowed.
+    #   for foo() { }
+    - linters: [revive]
+      text: 'empty-block: this block is empty, you can remove it'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,17 @@ issues:
     - linters: [revive]
       text: 'empty-block: this block is empty, you can remove it'
 
+    # We're using a pretty pedantic style for revive.
+    # Generated files cannot always comply with it, so omit them.
+    - linters: [revive]
+      path: '_gen.go$'
+
+    # Also opt-out revive for source files used in examples.
+    # The contents of those source files affect the documentation,
+    # so we want to control their contents.
+    - linters: [revive]
+      path: 'docs/ex/.*.go$'
+
     # magic_gen has some generated code that writes to fields of a struct
     # that eventually goes unused.
     # This is a false positive -- that struct is intentionally unused.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,3 +51,10 @@ issues:
     #   for foo() { }
     - linters: [revive]
       text: 'empty-block: this block is empty, you can remove it'
+
+    # magic_gen has some generated code that writes to fields of a struct
+    # that eventually goes unused.
+    # This is a false positive -- that struct is intentionally unused.
+    - linters: [govet]
+      path: examples/magic_gen.go
+      text: 'unusedwrite: unused write to field'

--- a/cmd/cff/main.go
+++ b/cmd/cff/main.go
@@ -1,3 +1,11 @@
+// cff is a library and code generator for Go
+// that makes it easy to write concurrent code.
+//
+// It allows you to write panic-safe code with bounded resource consumption,
+// operating on a complex dependency graph of interdependent tasks,
+// or a simple collection of independent tasks.
+//
+// See the documentation at https://uber-go.github.io/cff/ for more details.
 package main
 
 import (

--- a/examples/gen.go
+++ b/examples/gen.go
@@ -1,3 +1,6 @@
+// Package example holds test examples for cff.
+//
+// In the future, this may hold user-facing examples.
 package example
 
 //go:generate cff -file magic.go -genmode source-map .

--- a/examples/magic.go
+++ b/examples/magic.go
@@ -21,13 +21,15 @@ type Response struct {
 	MessageIDs []string
 }
 
-type fooHandler struct {
+// FooHandler does things.
+type FooHandler struct {
 	mgr   *ManagerRepository
 	users *UserRepository
 	ses   *SESClient
 }
 
-func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, error) {
+// HandleFoo handles foo requests.
+func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, error) {
 	var res *Response
 	err := cff.Flow(ctx,
 		cff.Params(req),
@@ -74,6 +76,9 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			}),
 		),
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	err = cff.Parallel(
 		ctx,
@@ -130,7 +135,11 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			map[string]int{"a": 1, "b": 2, "c": 3},
 		),
 	)
-	return res, err
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }
 
 // ManagerRepository TODO

--- a/examples/magic_gen.go
+++ b/examples/magic_gen.go
@@ -23,73 +23,75 @@ type Response struct {
 	MessageIDs []string
 }
 
-type fooHandler struct {
+// FooHandler does things.
+type FooHandler struct {
 	mgr   *ManagerRepository
 	users *UserRepository
 	ses   *SESClient
 }
 
-func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, error) {
+// HandleFoo handles foo requests.
+func (h *FooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, error) {
 	var res *Response
 	err := func() (err error) {
-		/*line magic.go:32:18*/
-		_32_18 := ctx
-		/*line magic.go:33:14*/
-		_33_14 := req
-		/*line magic.go:34:15*/
-		_34_15 := &res
-		/*line magic.go:35:19*/
-		_35_19 := 8
-		/*line magic.go:38:4*/
-		_38_4 := func(req *Request) (*GetManagerRequest, *ListUsersRequest) {
+		/*line magic.go:34:18*/
+		_34_18 := ctx
+		/*line magic.go:35:14*/
+		_35_14 := req
+		/*line magic.go:36:15*/
+		_36_15 := &res
+		/*line magic.go:37:19*/
+		_37_19 := 8
+		/*line magic.go:40:4*/
+		_40_4 := func(req *Request) (*GetManagerRequest, *ListUsersRequest) {
 			return &GetManagerRequest{
 					LDAPGroup: req.LDAPGroup,
 				}, &ListUsersRequest{
 					LDAPGroup: req.LDAPGroup,
 				}
 		}
-		/*line magic.go:46:4*/
-		_46_4 := h.mgr.Get
-		/*line magic.go:47:12*/
-		_47_12 := h.ses.BatchSendEmail
-		/*line magic.go:49:4*/
-		_49_4 := func(responses []*SendEmailResponse) *Response {
+		/*line magic.go:48:4*/
+		_48_4 := h.mgr.Get
+		/*line magic.go:49:12*/
+		_49_12 := h.ses.BatchSendEmail
+		/*line magic.go:51:4*/
+		_51_4 := func(responses []*SendEmailResponse) *Response {
 			var r Response
 			for _, res := range responses {
 				r.MessageIDs = append(r.MessageIDs, res.MessageID)
 			}
 			return &r
 		}
-		/*line magic.go:58:4*/
-		_58_4 := h.users.List
-		/*line magic.go:59:18*/
-		_59_18 := func(req *GetManagerRequest) bool {
+		/*line magic.go:60:4*/
+		_60_4 := h.users.List
+		/*line magic.go:61:18*/
+		_61_18 := func(req *GetManagerRequest) bool {
 			return req.LDAPGroup != "everyone"
 		}
-		/*line magic.go:62:21*/
-		_62_21 := &ListUsersResponse{}
-		/*line magic.go:65:4*/
-		_65_4 := func(mgr *GetManagerResponse, users *ListUsersResponse) []*SendEmailRequest {
+		/*line magic.go:64:21*/
+		_64_21 := &ListUsersResponse{}
+		/*line magic.go:67:4*/
+		_67_4 := func(mgr *GetManagerResponse, users *ListUsersResponse) []*SendEmailRequest {
 			var reqs []*SendEmailRequest
 			for _, u := range users.Emails {
 				reqs = append(reqs, &SendEmailRequest{Address: u})
 			}
 			return reqs
 		}
-		/*line magic.go:72:18*/
-		_72_18 := func(req *GetManagerRequest) bool {
+		/*line magic.go:74:18*/
+		_74_18 := func(req *GetManagerRequest) bool {
 			return req.LDAPGroup != "everyone"
 		}
 
-		/*line magic_gen.go:85*/
-		ctx := _32_18
-		var v1 *Request = _33_14
+		/*line magic_gen.go:87*/
+		ctx := _34_18
+		var v1 *Request = _35_14
 		emitter := cff.NopEmitter()
 
 		var (
 			flowInfo = &cff.FlowInfo{
 				File:   "go.uber.org/cff/examples/magic.go",
-				Line:   32,
+				Line:   34,
 				Column: 9,
 			}
 			flowEmitter = cff.NopFlowEmitter()
@@ -113,7 +115,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 		sched := cff.NewScheduler(
 			cff.SchedulerParams{
-				Concurrency: _35_19, Emitter: schedEmitter,
+				Concurrency: _37_19, Emitter: schedEmitter,
 			},
 		)
 
@@ -131,7 +133,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			}
 		}()
 
-		// go.uber.org/cff/examples/magic.go:38:4
+		// go.uber.org/cff/examples/magic.go:40:4
 		var (
 			v2 *GetManagerRequest
 			v3 *ListUsersRequest
@@ -162,7 +164,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer task0.ran.Store(true)
 
-			v2, v3 = _38_4(v1)
+			v2, v3 = _40_4(v1)
 
 			taskEmitter.TaskSuccess(ctx)
 
@@ -174,7 +176,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		})
 		tasks = append(tasks, task0)
 
-		// go.uber.org/cff/examples/magic.go:46:4
+		// go.uber.org/cff/examples/magic.go:48:4
 		var (
 			v4 *GetManagerResponse
 		)
@@ -204,7 +206,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer task1.ran.Store(true)
 
-			v4, err = _46_4(v2)
+			v4, err = _48_4(v2)
 
 			if err != nil {
 				taskEmitter.TaskError(ctx, err)
@@ -224,7 +226,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		})
 		tasks = append(tasks, task1)
 
-		// go.uber.org/cff/examples/magic.go:59:4
+		// go.uber.org/cff/examples/magic.go:61:4
 		var p0 bool
 		var p0PanicRecover interface{}
 		pred1 := new(struct {
@@ -238,7 +240,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					p0PanicRecover = recovered
 				}
 			}()
-			p0 = _59_18(v2)
+			p0 = _61_18(v2)
 			return nil
 		}
 
@@ -249,7 +251,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			},
 		})
 
-		// go.uber.org/cff/examples/magic.go:58:4
+		// go.uber.org/cff/examples/magic.go:60:4
 		var (
 			v5 *ListUsersResponse
 		)
@@ -276,7 +278,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 				}
 				if recovered != nil {
 					taskEmitter.TaskPanicRecovered(ctx, recovered)
-					v5, err = _62_21, nil
+					v5, err = _64_21, nil
 				}
 			}()
 
@@ -286,11 +288,11 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer task4.ran.Store(true)
 
-			v5, err = _58_4(v3)
+			v5, err = _60_4(v3)
 
 			if err != nil {
 				taskEmitter.TaskErrorRecovered(ctx, err)
-				v5, err = _62_21, nil
+				v5, err = _64_21, nil
 			} else {
 				taskEmitter.TaskSuccess(ctx)
 			}
@@ -307,7 +309,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		})
 		tasks = append(tasks, task4)
 
-		// go.uber.org/cff/examples/magic.go:72:4
+		// go.uber.org/cff/examples/magic.go:74:4
 		var p1 bool
 		var p1PanicRecover interface{}
 		pred2 := new(struct {
@@ -321,7 +323,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					p1PanicRecover = recovered
 				}
 			}()
-			p1 = _72_18(v2)
+			p1 = _74_18(v2)
 			return nil
 		}
 
@@ -332,7 +334,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			},
 		})
 
-		// go.uber.org/cff/examples/magic.go:65:4
+		// go.uber.org/cff/examples/magic.go:67:4
 		var (
 			v6 []*SendEmailRequest
 		)
@@ -369,7 +371,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer task5.ran.Store(true)
 
-			v6 = _65_4(v4, v5)
+			v6 = _67_4(v4, v5)
 
 			taskEmitter.TaskSuccess(ctx)
 
@@ -386,7 +388,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		})
 		tasks = append(tasks, task5)
 
-		// go.uber.org/cff/examples/magic.go:47:12
+		// go.uber.org/cff/examples/magic.go:49:12
 		var (
 			v7 []*SendEmailResponse
 		)
@@ -416,7 +418,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer task2.ran.Store(true)
 
-			v7, err = _47_12(v6)
+			v7, err = _49_12(v6)
 
 			if err != nil {
 				taskEmitter.TaskError(ctx, err)
@@ -436,7 +438,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		})
 		tasks = append(tasks, task2)
 
-		// go.uber.org/cff/examples/magic.go:49:4
+		// go.uber.org/cff/examples/magic.go:51:4
 		var (
 			v8 *Response
 		)
@@ -466,7 +468,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer task3.ran.Store(true)
 
-			v8 = _49_4(v7)
+			v8 = _51_4(v7)
 
 			taskEmitter.TaskSuccess(ctx)
 
@@ -486,77 +488,80 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			return err
 		}
 
-		*(_34_15) = v8 // *go.uber.org/cff/examples.Response
+		*(_36_15) = v8 // *go.uber.org/cff/examples.Response
 
 		flowEmitter.FlowSuccess(ctx)
-		return nil /*line magic.go:75*/
+		return nil /*line magic.go:77*/
 	}()
+	if err != nil {
+		return nil, err
+	}
 
 	err = func() (err error) {
-		/*line magic.go:79:3*/
-		_79_3 := ctx
-		/*line magic.go:80:19*/
-		_80_19 := 2
-		/*line magic.go:81:23*/
-		_81_23 := true
-		/*line magic.go:83:4*/
-		_83_4 := func(_ context.Context) error {
+		/*line magic.go:84:3*/
+		_84_3 := ctx
+		/*line magic.go:85:19*/
+		_85_19 := 2
+		/*line magic.go:86:23*/
+		_86_23 := true
+		/*line magic.go:88:4*/
+		_88_4 := func(_ context.Context) error {
 			return SendMessage()
 		}
-		/*line magic.go:86:4*/
-		_86_4 := SendMessage
-		/*line magic.go:89:4*/
-		_89_4 := func() error {
-			return SendMessage()
-		}
+		/*line magic.go:91:4*/
+		_91_4 := SendMessage
 		/*line magic.go:94:4*/
-		_94_4 := func(ctx context.Context, idx int, s string) error {
+		_94_4 := func() error {
+			return SendMessage()
+		}
+		/*line magic.go:99:4*/
+		_99_4 := func(ctx context.Context, idx int, s string) error {
 			_ = fmt.Sprintf("%d and %q", idx, s)
 			_, _ = ctx.Deadline()
 			return nil
 		}
-		/*line magic.go:99:4*/
-		_99_4 := []string{"message", "to", "send"}
-		/*line magic.go:102:4*/
-		_102_4 := func(ctx context.Context, s string) error {
+		/*line magic.go:104:4*/
+		_104_4 := []string{"message", "to", "send"}
+		/*line magic.go:107:4*/
+		_107_4 := func(ctx context.Context, s string) error {
 			_ = fmt.Sprintf("%q", s)
 			_, _ = ctx.Deadline()
 			return nil
 		}
-		/*line magic.go:107:4*/
-		_107_4 := []string{"message", "to", "send"}
-		/*line magic.go:110:4*/
-		_110_4 := func(ctx context.Context, idx int, s string) error {
+		/*line magic.go:112:4*/
+		_112_4 := []string{"message", "to", "send"}
+		/*line magic.go:115:4*/
+		_115_4 := func(ctx context.Context, idx int, s string) error {
 			_ = fmt.Sprintf("%d and %q", idx, s)
 			ctx.Deadline()
 			return nil
 		}
-		/*line magic.go:115:4*/
-		_115_4 := []string{"more", "messages", "sent"}
-		/*line magic.go:118:4*/
-		_118_4 := func(ctx context.Context, key string, value string) error {
+		/*line magic.go:120:4*/
+		_120_4 := []string{"more", "messages", "sent"}
+		/*line magic.go:123:4*/
+		_123_4 := func(ctx context.Context, key string, value string) error {
 			_ = fmt.Sprintf("%q : %q", key, value)
 			_, _ = ctx.Deadline()
 			return nil
 		}
-		/*line magic.go:123:4*/
-		_123_4 := map[string]string{"key": "value"}
-		/*line magic.go:126:4*/
-		_126_4 := func(ctx context.Context, key string, value int) error {
+		/*line magic.go:128:4*/
+		_128_4 := map[string]string{"key": "value"}
+		/*line magic.go:131:4*/
+		_131_4 := func(ctx context.Context, key string, value int) error {
 			_ = fmt.Sprintf("%q: %v", key, value)
 			return nil
 		}
-		/*line magic.go:130:4*/
-		_130_4 := map[string]int{"a": 1, "b": 2, "c": 3}
+		/*line magic.go:135:4*/
+		_135_4 := map[string]int{"a": 1, "b": 2, "c": 3}
 
-		/*line magic_gen.go:553*/
-		ctx := _79_3
+		/*line magic_gen.go:558*/
+		ctx := _84_3
 		emitter := cff.NopEmitter()
 
 		var (
 			parallelInfo = &cff.ParallelInfo{
 				File:   "go.uber.org/cff/examples/magic.go",
-				Line:   78,
+				Line:   83,
 				Column: 8,
 			}
 			directiveInfo = &cff.DirectiveInfo{
@@ -588,8 +593,8 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 		sched := cff.NewScheduler(
 			cff.SchedulerParams{
-				Concurrency: _80_19, Emitter: schedEmitter,
-				ContinueOnError: _81_23,
+				Concurrency: _85_19, Emitter: schedEmitter,
+				ContinueOnError: _86_23,
 			},
 		)
 
@@ -606,7 +611,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			}
 		}()
 
-		// go.uber.org/cff/examples/magic.go:83:4
+		// go.uber.org/cff/examples/magic.go:88:4
 		task6 := new(struct {
 			emitter cff.TaskEmitter
 			fn      func(context.Context) error
@@ -632,7 +637,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer task6.ran.Store(true)
 
-			err = _83_4(ctx)
+			err = _88_4(ctx)
 
 			if err != nil {
 				taskEmitter.TaskError(ctx, err)
@@ -647,7 +652,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		})
 		tasks = append(tasks, task6)
 
-		// go.uber.org/cff/examples/magic.go:86:4
+		// go.uber.org/cff/examples/magic.go:91:4
 		task7 := new(struct {
 			emitter cff.TaskEmitter
 			fn      func(context.Context) error
@@ -673,7 +678,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer task7.ran.Store(true)
 
-			err = _86_4()
+			err = _91_4()
 
 			if err != nil {
 				taskEmitter.TaskError(ctx, err)
@@ -688,7 +693,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		})
 		tasks = append(tasks, task7)
 
-		// go.uber.org/cff/examples/magic.go:89:4
+		// go.uber.org/cff/examples/magic.go:94:4
 		task8 := new(struct {
 			emitter cff.TaskEmitter
 			fn      func(context.Context) error
@@ -714,7 +719,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 
 			defer task8.ran.Store(true)
 
-			err = _89_4()
+			err = _94_4()
 
 			if err != nil {
 				taskEmitter.TaskError(ctx, err)
@@ -729,8 +734,8 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 		})
 		tasks = append(tasks, task8)
 
-		// go.uber.org/cff/examples/magic.go:93:3
-		sliceTask9Slice := _99_4
+		// go.uber.org/cff/examples/magic.go:98:3
+		sliceTask9Slice := _104_4
 		for idx, val := range sliceTask9Slice {
 			idx := idx
 			val := val
@@ -746,7 +751,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 						err = fmt.Errorf("panic: %v", recovered)
 					}
 				}()
-				err = _94_4(ctx, idx, val)
+				err = _99_4(ctx, idx, val)
 				return
 			}
 			sched.Enqueue(ctx, cff.Job{
@@ -754,8 +759,8 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			})
 		}
 
-		// go.uber.org/cff/examples/magic.go:101:3
-		sliceTask10Slice := _107_4
+		// go.uber.org/cff/examples/magic.go:106:3
+		sliceTask10Slice := _112_4
 		for _, val := range sliceTask10Slice {
 
 			val := val
@@ -771,7 +776,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 						err = fmt.Errorf("panic: %v", recovered)
 					}
 				}()
-				err = _102_4(ctx, val)
+				err = _107_4(ctx, val)
 				return
 			}
 			sched.Enqueue(ctx, cff.Job{
@@ -779,8 +784,8 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			})
 		}
 
-		// go.uber.org/cff/examples/magic.go:109:3
-		sliceTask11Slice := _115_4
+		// go.uber.org/cff/examples/magic.go:114:3
+		sliceTask11Slice := _120_4
 		for idx, val := range sliceTask11Slice {
 			idx := idx
 			val := val
@@ -796,7 +801,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 						err = fmt.Errorf("panic: %v", recovered)
 					}
 				}()
-				err = _110_4(ctx, idx, val)
+				err = _115_4(ctx, idx, val)
 				return
 			}
 			sched.Enqueue(ctx, cff.Job{
@@ -804,8 +809,8 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			})
 		}
 
-		// go.uber.org/cff/examples/magic.go:117:3
-		for key, val := range _123_4 {
+		// go.uber.org/cff/examples/magic.go:122:3
+		for key, val := range _128_4 {
 			key := key
 			val := val
 			mapTask12 := new(struct {
@@ -821,7 +826,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					}
 				}()
 
-				err = _118_4(ctx, key, val)
+				err = _123_4(ctx, key, val)
 				return
 			}
 
@@ -830,8 +835,8 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			})
 		}
 
-		// go.uber.org/cff/examples/magic.go:125:3
-		for key, val := range _130_4 {
+		// go.uber.org/cff/examples/magic.go:130:3
+		for key, val := range _135_4 {
 			key := key
 			val := val
 			mapTask13 := new(struct {
@@ -847,7 +852,7 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 					}
 				}()
 
-				err = _126_4(ctx, key, val)
+				err = _131_4(ctx, key, val)
 				return
 			}
 
@@ -861,9 +866,13 @@ func (h *fooHandler) HandleFoo(ctx context.Context, req *Request) (*Response, er
 			return err
 		}
 		parallelEmitter.ParallelSuccess(ctx)
-		return nil /*line magic.go:131*/
+		return nil /*line magic.go:136*/
 	}()
-	return res, err
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }
 
 // ManagerRepository TODO

--- a/internal/buildtag_test.go
+++ b/internal/buildtag_test.go
@@ -221,7 +221,8 @@ func TestStickyErrWriter(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		var buff bytes.Buffer
 		w := &stickyErrWriter{W: &buff}
-		io.WriteString(w, "hello")
+		_, err := io.WriteString(w, "hello")
+		assert.NoError(t, err, "stickyErrWriter should not return an error")
 		assert.NoError(t, w.Err)
 	})
 
@@ -230,8 +231,13 @@ func TestStickyErrWriter(t *testing.T) {
 		w := &stickyErrWriter{
 			W: &errWriter{Err: giveErr},
 		}
-		io.WriteString(w, "hello")
-		io.WriteString(w, "world")
+
+		_, err := io.WriteString(w, "hello")
+		assert.NoError(t, err, "stickyErrWriter should not return an error")
+
+		_, err = io.WriteString(w, "world")
+		assert.NoError(t, err, "stickyErrWriter should not return an error")
+
 		assert.ErrorIs(t, w.Err, giveErr)
 	})
 }

--- a/internal/compile.go
+++ b/internal/compile.go
@@ -1,3 +1,4 @@
+// Package internal is the internal implementation of the cff compiler.
 package internal
 
 import (

--- a/internal/emittertest/gen.go
+++ b/internal/emittertest/gen.go
@@ -1,3 +1,4 @@
+// Package emittertest provides testing utilities for cff emitters.
 package emittertest
 
 //go:generate mockgen -destination mock_emitter.go -package emittertest go.uber.org/cff Emitter,TaskEmitter,FlowEmitter,ParallelEmitter,SchedulerEmitter

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -1,3 +1,5 @@
+// Package flag implements command line flag utilities
+// for the cff command.
 package flag
 
 import "flag"

--- a/internal/flow_modifier.go
+++ b/internal/flow_modifier.go
@@ -112,10 +112,7 @@ func (fm *flowModifier) GenImpl(p modifier.GenParams) error {
 	if err != nil {
 		return err
 	}
-	if err := mt.ExecuteTemplate(p.Writer, _flowModifierRootTmpl, fm); err != nil {
-		return err
-	}
-	return nil
+	return mt.ExecuteTemplate(p.Writer, _flowModifierRootTmpl, fm)
 }
 
 func (fm *flowModifier) Expr() ast.Expr {

--- a/internal/gendirectives/main.go
+++ b/internal/gendirectives/main.go
@@ -19,6 +19,8 @@ import (
 	"log"
 	"os"
 	"text/template"
+
+	"go.uber.org/multierr"
 )
 
 func main() {
@@ -28,7 +30,7 @@ func main() {
 	}
 }
 
-func run(args []string) error {
+func run(args []string) (err error) {
 	if len(args) != 2 {
 		return fmt.Errorf("usage: %v path_to_cff.go output_file.go", os.Args[0])
 	}
@@ -61,7 +63,7 @@ func run(args []string) error {
 	if err != nil {
 		return fmt.Errorf("create %q: %w", output, err)
 	}
-	defer out.Close()
+	defer multierr.AppendInvoke(&err, multierr.Close(out))
 
 	return _tmpl.Execute(out, td)
 }

--- a/internal/gendirectives/main_test.go
+++ b/internal/gendirectives/main_test.go
@@ -10,9 +10,7 @@ import (
 )
 
 func TestRunErrors(t *testing.T) {
-	dir, err := os.MkdirTemp("", "cff.go")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	t.Run("too few arguments", func(t *testing.T) {
 		require.Error(t, run([]string{"foo"}))
@@ -20,7 +18,7 @@ func TestRunErrors(t *testing.T) {
 
 	t.Run("unable to parse", func(t *testing.T) {
 		input := filepath.Join(dir, "bad_syntax.go")
-		require.NoError(t, os.WriteFile(input, []byte("foo"), 0644))
+		require.NoError(t, os.WriteFile(input, []byte("foo"), 0o644))
 
 		err := run([]string{input, filepath.Join(dir, "out.go")})
 		require.Error(t, err)
@@ -29,7 +27,7 @@ func TestRunErrors(t *testing.T) {
 
 	t.Run("unable to write", func(t *testing.T) {
 		input := filepath.Join(dir, "cff.go")
-		require.NoError(t, os.WriteFile(input, []byte(_sampleFile), 0644))
+		require.NoError(t, os.WriteFile(input, []byte(_sampleFile), 0o644))
 
 		err := run([]string{input, filepath.Join(dir, "does_not_exist", "out.go")})
 		require.Error(t, err)
@@ -48,12 +46,10 @@ func (*Bar) Baz()
 `
 
 func TestRun(t *testing.T) {
-	dir, err := os.MkdirTemp("", "cff.go")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	input := filepath.Join(dir, "cff.go")
-	require.NoError(t, os.WriteFile(input, []byte(_sampleFile), 0644))
+	require.NoError(t, os.WriteFile(input, []byte(_sampleFile), 0o644))
 
 	output := filepath.Join(dir, "out.go")
 	require.NoError(t, run([]string{input, output}))

--- a/internal/modifier/concurrency.go
+++ b/internal/modifier/concurrency.go
@@ -41,10 +41,7 @@ func (cm *concurrencyModifier) GenImpl(p GenParams) error {
 	if err != nil {
 		return err
 	}
-	if err := modifierTmpl.ExecuteTemplate(p.Writer, _concurrencyTmplName, cm); err != nil {
-		return err
-	}
-	return nil
+	return modifierTmpl.ExecuteTemplate(p.Writer, _concurrencyTmplName, cm)
 }
 
 func (cm *concurrencyModifier) Expr() ast.Expr {

--- a/internal/modifier/factory.go
+++ b/internal/modifier/factory.go
@@ -83,10 +83,7 @@ func (fm *funcModifier) GenImpl(p GenParams) error {
 	if err != nil {
 		return err
 	}
-	if err := mt.ExecuteTemplate(p.Writer, _funcTmpl, fm); err != nil {
-		return err
-	}
-	return nil
+	return mt.ExecuteTemplate(p.Writer, _funcTmpl, fm)
 }
 
 // Expr returns the ast.Expr replaced by the modifier function.

--- a/internal/modifier/modifiers.go
+++ b/internal/modifier/modifiers.go
@@ -1,3 +1,5 @@
+// Package modifier implements modifier-based code generation
+// for cff directives.
 package modifier
 
 import (

--- a/internal/pkg/gopackages.go
+++ b/internal/pkg/gopackages.go
@@ -1,3 +1,7 @@
+// Package pkg defines the interface for loading Go packages.
+//
+// It provides a pluggable means for systems like Bazel and Buck
+// to inject an alternative package loading mechanism instead of go/packages.
 package pkg
 
 import (

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -205,7 +205,9 @@ func TestScheduler_ContinueOnError(t *testing.T) {
 		// Enqueue a leaf dependency job that will error.
 		failDep := sched.Enqueue(context.Background(), Job{
 			Run: func(c context.Context) error {
-				defer blocker.Run(c)
+				defer func() {
+					assert.NoError(t, blocker.Run(c))
+				}()
 				return errors.New("sad times")
 			},
 		})
@@ -265,7 +267,9 @@ func TestScheduler_ContinueOnError(t *testing.T) {
 		// Enqueue a leaf dependency job that will error.
 		failDep := sched.Enqueue(context.Background(), Job{
 			Run: func(c context.Context) error {
-				defer blocker.Run(c)
+				defer func() {
+					assert.NoError(t, blocker.Run(c))
+				}()
 				return errors.New("sad times")
 			},
 		})

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,13 +2,9 @@ module go.uber.org/cff/tools
 
 go 1.20
 
-require (
-	github.com/bwplotka/mdox v0.9.0
-	honnef.co/go/tools v0.4.5
-)
+require github.com/bwplotka/mdox v0.9.0
 
 require (
-	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20210810103848-727f02f4c51c // indirect
 	github.com/PuerkitoBio/goquery v1.8.0 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
@@ -73,8 +69,6 @@ require (
 	github.com/theckman/yacspin v0.13.12 // indirect
 	github.com/yuin/goldmark v1.5.2 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
-	golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a // indirect
-	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -57,8 +57,6 @@ github.com/Azure/go-autorest v11.1.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSW
 github.com/Azure/go-autorest/tracing v0.1.0/go.mod h1:ROEEAFwXycQw7Sn3DXNtEedEvdeRAgDr0izn4z5Ij88=
 github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69/go.mod h1:L1AbZdiDllfyYH5l5OkAaZtk7VkWe89bPJFmnDBNHxg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
-github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
 github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtixis4Tib9if0=
@@ -759,8 +757,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a h1:Jw5wfR+h9mnIYH+OtGT2im5wV1YGGDora5vTv/aa5bE=
-golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.0.0-20191214001246-9130b4cfad52/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -786,8 +782,6 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
-golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -868,7 +862,6 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1157,8 +1150,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.4.5 h1:YGD4H+SuIOOqsyoLOpZDWcieM28W47/zRO7f+9V3nvo=
-honnef.co/go/tools v0.4.5/go.mod h1:GUV+uIBCLpdf0/v6UhHHG/yzI/z6qPskBeQCjcNB96k=
 pack.ag/amqp v0.8.0/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=
 pack.ag/amqp v0.11.0/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -6,5 +6,4 @@ package tools
 // Tools we use during development.
 import (
 	_ "github.com/bwplotka/mdox"
-	_ "honnef.co/go/tools/cmd/staticcheck"
 )


### PR DESCRIPTION
Similarly to Zap, switch to using golangci-lint to run linters.
In CI, lint will now run in a separate job than the tests.
This obviates the need for staticcheck in tools/.

Exclusions were added for lint rules that cannot be fixed in generated code.
Specifically, revive was opted out for generated code in general
because its pedantic style requirements cannot be met easily in generated code.

<details>
<summary>Lint issues fixed</summary>

```
cmd/cff/main.go:1:1: package-comments: should have a package comment (revive)
internal/aquaregia_test.go:1:1: package-comments: should have a package comment (revive)
internal/buildtag_test.go:224:17: Error return value of `io.WriteString` is not checked (errcheck)
internal/buildtag_test.go:233:17: Error return value of `io.WriteString` is not checked (errcheck)
internal/buildtag_test.go:234:17: Error return value of `io.WriteString` is not checked (errcheck)
internal/emittertest/gen.go:1:1: package-comments: should have a package comment (revive)
internal/flag/flag.go:1:1: package-comments: should have a package comment (revive)
internal/flow_modifier.go:115:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
internal/gen.go:221:10: Error return value of `w.Write` is not checked (errcheck)
internal/gen.go:226:9: Error return value of `w.Write` is not checked (errcheck)
internal/gen.go:394:13: Error return value of `format.Node` is not checked (errcheck)
internal/gendirectives/main.go:64:17: Error return value of `out.Close` is not checked (errcheck)
internal/gendirectives/main_test.go:15:20: Error return value of `os.RemoveAll` is not checked (errcheck)
internal/gendirectives/main_test.go:53:20: Error return value of `os.RemoveAll` is not checked (errcheck)
internal/modifier/concurrency.go:1:1: package-comments: should have a package comment (revive)
internal/modifier/concurrency.go:44:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
internal/modifier/factory.go:86:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
internal/pkg/gopackages.go:1:1: package-comments: should have a package comment (revive)
scheduler/scheduler_test.go:208:22: Error return value of `blocker.Run` is not checked (errcheck)
scheduler/scheduler_test.go:268:22: Error return value of `blocker.Run` is not checked (errcheck)
```

</details>
