### PR TITLE
ci: Run 'make generate' with coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,12 @@ jobs:
         version: latest
         args: --version  # make lint will run the linter
 
+    - run: make lint
+      name: Lint
+
     # Verify that all generated code is up-to-date.
     - name: Regenerate code
-      run: make generate
+      run: make generate-cover
     - name: Verify unchanged
       run: |
         if ! git diff --quiet; then
@@ -38,8 +41,8 @@ jobs:
           exit 1
         fi
 
-    - run: make lint
-      name: Lint
+    - name: Upload coverage to codecov.io
+      uses: codecov/codecov-action@v3
 
   build-test:
     name: Build and test


### PR DESCRIPTION
This adds a 'make generate-cover' target that
uses Go 1.20's support for coverage-instrumented binaries
to build a 'cff' executable that tracks coverage.
It then runs 'make generate' with that binary,
and collects the coverage data produced by it.

With this change, we'll include coverage of 'make generate'
in the coverage data for the project.

In the Makefile, this makes use of `?=`
to override the GOBIN and BUILD_FLAGS
without creating too much fuss or duplication otherwise.

Resolves #57
