### PR TITLE
lint: Don't use '.' imports

### DIFF
--- a/emitter_stack_test.go
+++ b/emitter_stack_test.go
@@ -7,37 +7,37 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	. "go.uber.org/cff"
+	"go.uber.org/cff"
 	"go.uber.org/cff/internal/emittertest"
 )
 
 func TestEmitterStackConstruction(t *testing.T) {
 	tests := []struct {
 		desc string
-		give []Emitter
+		give []cff.Emitter
 	}{
 		{desc: "empty"},
 		{
 			desc: "single",
-			give: []Emitter{
-				NopEmitter(),
+			give: []cff.Emitter{
+				cff.NopEmitter(),
 			},
 		},
 		{
 			desc: "multiple",
-			give: []Emitter{
-				NopEmitter(),
-				NopEmitter(),
-				NopEmitter(),
+			give: []cff.Emitter{
+				cff.NopEmitter(),
+				cff.NopEmitter(),
+				cff.NopEmitter(),
 			},
 		},
 		{
 			desc: "nested",
-			give: []Emitter{
-				NopEmitter(),
-				EmitterStack(
-					NopEmitter(),
-					NopEmitter(),
+			give: []cff.Emitter{
+				cff.NopEmitter(),
+				cff.EmitterStack(
+					cff.NopEmitter(),
+					cff.NopEmitter(),
 				),
 			},
 		},
@@ -47,10 +47,10 @@ func TestEmitterStackConstruction(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx := context.Background()
 
-			e := EmitterStack(tt.give...)
-			e.FlowInit(&FlowInfo{Name: "foo"}).
+			e := cff.EmitterStack(tt.give...)
+			e.FlowInit(&cff.FlowInfo{Name: "foo"}).
 				FlowDone(ctx, time.Second)
-			e.ParallelInit(&ParallelInfo{Name: "bar"}).
+			e.ParallelInit(&cff.ParallelInfo{Name: "bar"}).
 				ParallelDone(ctx, time.Second)
 		})
 	}
@@ -66,7 +66,7 @@ type testStructs struct {
 	emitter2  *emittertest.MockEmitter
 	parallel1 *emittertest.MockParallelEmitter
 	parallel2 *emittertest.MockParallelEmitter
-	stack     Emitter
+	stack     cff.Emitter
 }
 
 func mocks(t *testing.T) testStructs {
@@ -80,7 +80,7 @@ func mocks(t *testing.T) testStructs {
 	m.emitter2 = emittertest.NewMockEmitter(m.ctrl)
 	m.parallel1 = emittertest.NewMockParallelEmitter(m.ctrl)
 	m.parallel2 = emittertest.NewMockParallelEmitter(m.ctrl)
-	m.stack = EmitterStack(
+	m.stack = cff.EmitterStack(
 		m.emitter1,
 		m.emitter2,
 	)
@@ -94,9 +94,9 @@ func TestEmitterStack(t *testing.T) {
 			m := mocks(t)
 			defer m.ctrl.Finish()
 
-			m.emitter1.EXPECT().FlowInit(&FlowInfo{"foo", "foo.go", 0, 0}).Times(1)
-			m.emitter2.EXPECT().FlowInit(&FlowInfo{"foo", "foo.go", 0, 0}).Times(1)
-			m.stack.FlowInit(&FlowInfo{"foo", "foo.go", 0, 0})
+			m.emitter1.EXPECT().FlowInit(&cff.FlowInfo{"foo", "foo.go", 0, 0}).Times(1)
+			m.emitter2.EXPECT().FlowInit(&cff.FlowInfo{"foo", "foo.go", 0, 0}).Times(1)
+			m.stack.FlowInit(&cff.FlowInfo{"foo", "foo.go", 0, 0})
 		})
 
 		t.Run("FlowSuccess", func(t *testing.T) {
@@ -104,37 +104,37 @@ func TestEmitterStack(t *testing.T) {
 			m := mocks(t)
 			defer m.ctrl.Finish()
 
-			m.emitter1.EXPECT().FlowInit(&FlowInfo{"foo", "foo.go", 0, 0}).Return(m.flow1)
-			m.emitter2.EXPECT().FlowInit(&FlowInfo{"foo", "foo.go", 0, 0}).Return(m.flow2)
+			m.emitter1.EXPECT().FlowInit(&cff.FlowInfo{"foo", "foo.go", 0, 0}).Return(m.flow1)
+			m.emitter2.EXPECT().FlowInit(&cff.FlowInfo{"foo", "foo.go", 0, 0}).Return(m.flow2)
 
 			m.flow1.EXPECT().FlowSuccess(ctx)
 			m.flow2.EXPECT().FlowSuccess(ctx)
-			m.stack.FlowInit(&FlowInfo{"foo", "foo.go", 0, 0}).FlowSuccess(ctx)
+			m.stack.FlowInit(&cff.FlowInfo{"foo", "foo.go", 0, 0}).FlowSuccess(ctx)
 		})
 		t.Run("FlowError", func(t *testing.T) {
 			ctx := context.Background()
 			m := mocks(t)
 			defer m.ctrl.Finish()
 
-			m.emitter1.EXPECT().FlowInit(&FlowInfo{"foo", "foo.go", 0, 0}).Return(m.flow1)
-			m.emitter2.EXPECT().FlowInit(&FlowInfo{"foo", "foo.go", 0, 0}).Return(m.flow2)
+			m.emitter1.EXPECT().FlowInit(&cff.FlowInfo{"foo", "foo.go", 0, 0}).Return(m.flow1)
+			m.emitter2.EXPECT().FlowInit(&cff.FlowInfo{"foo", "foo.go", 0, 0}).Return(m.flow2)
 
 			err := errors.New("foobar")
 			m.flow1.EXPECT().FlowError(ctx, err)
 			m.flow2.EXPECT().FlowError(ctx, err)
-			m.stack.FlowInit(&FlowInfo{"foo", "foo.go", 0, 0}).FlowError(ctx, err)
+			m.stack.FlowInit(&cff.FlowInfo{"foo", "foo.go", 0, 0}).FlowError(ctx, err)
 		})
 		t.Run("FlowDone", func(t *testing.T) {
 			ctx := context.Background()
 			m := mocks(t)
 			defer m.ctrl.Finish()
 
-			m.emitter1.EXPECT().FlowInit(&FlowInfo{"foo", "foo.go", 0, 0}).Return(m.flow1)
-			m.emitter2.EXPECT().FlowInit(&FlowInfo{"foo", "foo.go", 0, 0}).Return(m.flow2)
+			m.emitter1.EXPECT().FlowInit(&cff.FlowInfo{"foo", "foo.go", 0, 0}).Return(m.flow1)
+			m.emitter2.EXPECT().FlowInit(&cff.FlowInfo{"foo", "foo.go", 0, 0}).Return(m.flow2)
 
 			m.flow1.EXPECT().FlowDone(ctx, time.Duration(1))
 			m.flow2.EXPECT().FlowDone(ctx, time.Duration(1))
-			m.stack.FlowInit(&FlowInfo{"foo", "foo.go", 0, 0}).FlowDone(ctx, time.Duration(1))
+			m.stack.FlowInit(&cff.FlowInfo{"foo", "foo.go", 0, 0}).FlowDone(ctx, time.Duration(1))
 		})
 	})
 
@@ -143,9 +143,9 @@ func TestEmitterStack(t *testing.T) {
 			m := mocks(t)
 			defer m.ctrl.Finish()
 
-			m.emitter1.EXPECT().ParallelInit(&ParallelInfo{"foo", "foo.go", 0, 0}).Times(1)
-			m.emitter2.EXPECT().ParallelInit(&ParallelInfo{"foo", "foo.go", 0, 0}).Times(1)
-			m.stack.ParallelInit(&ParallelInfo{"foo", "foo.go", 0, 0})
+			m.emitter1.EXPECT().ParallelInit(&cff.ParallelInfo{"foo", "foo.go", 0, 0}).Times(1)
+			m.emitter2.EXPECT().ParallelInit(&cff.ParallelInfo{"foo", "foo.go", 0, 0}).Times(1)
+			m.stack.ParallelInit(&cff.ParallelInfo{"foo", "foo.go", 0, 0})
 		})
 
 		t.Run("ParallelSuccess", func(t *testing.T) {
@@ -153,37 +153,37 @@ func TestEmitterStack(t *testing.T) {
 			m := mocks(t)
 			defer m.ctrl.Finish()
 
-			m.emitter1.EXPECT().ParallelInit(&ParallelInfo{"foo", "foo.go", 0, 0}).Return(m.parallel1)
-			m.emitter2.EXPECT().ParallelInit(&ParallelInfo{"foo", "foo.go", 0, 0}).Return(m.parallel2)
+			m.emitter1.EXPECT().ParallelInit(&cff.ParallelInfo{"foo", "foo.go", 0, 0}).Return(m.parallel1)
+			m.emitter2.EXPECT().ParallelInit(&cff.ParallelInfo{"foo", "foo.go", 0, 0}).Return(m.parallel2)
 
 			m.parallel1.EXPECT().ParallelSuccess(ctx)
 			m.parallel2.EXPECT().ParallelSuccess(ctx)
-			m.stack.ParallelInit(&ParallelInfo{"foo", "foo.go", 0, 0}).ParallelSuccess(ctx)
+			m.stack.ParallelInit(&cff.ParallelInfo{"foo", "foo.go", 0, 0}).ParallelSuccess(ctx)
 		})
 		t.Run("ParallelError", func(t *testing.T) {
 			ctx := context.Background()
 			m := mocks(t)
 			defer m.ctrl.Finish()
 
-			m.emitter1.EXPECT().ParallelInit(&ParallelInfo{"foo", "foo.go", 0, 0}).Return(m.parallel1)
-			m.emitter2.EXPECT().ParallelInit(&ParallelInfo{"foo", "foo.go", 0, 0}).Return(m.parallel2)
+			m.emitter1.EXPECT().ParallelInit(&cff.ParallelInfo{"foo", "foo.go", 0, 0}).Return(m.parallel1)
+			m.emitter2.EXPECT().ParallelInit(&cff.ParallelInfo{"foo", "foo.go", 0, 0}).Return(m.parallel2)
 
 			err := errors.New("foobar")
 			m.parallel1.EXPECT().ParallelError(ctx, err)
 			m.parallel2.EXPECT().ParallelError(ctx, err)
-			m.stack.ParallelInit(&ParallelInfo{"foo", "foo.go", 0, 0}).ParallelError(ctx, err)
+			m.stack.ParallelInit(&cff.ParallelInfo{"foo", "foo.go", 0, 0}).ParallelError(ctx, err)
 		})
 		t.Run("ParallelDone", func(t *testing.T) {
 			ctx := context.Background()
 			m := mocks(t)
 			defer m.ctrl.Finish()
 
-			m.emitter1.EXPECT().ParallelInit(&ParallelInfo{"foo", "foo.go", 0, 0}).Return(m.parallel1)
-			m.emitter2.EXPECT().ParallelInit(&ParallelInfo{"foo", "foo.go", 0, 0}).Return(m.parallel2)
+			m.emitter1.EXPECT().ParallelInit(&cff.ParallelInfo{"foo", "foo.go", 0, 0}).Return(m.parallel1)
+			m.emitter2.EXPECT().ParallelInit(&cff.ParallelInfo{"foo", "foo.go", 0, 0}).Return(m.parallel2)
 
 			m.parallel1.EXPECT().ParallelDone(ctx, time.Duration(1))
 			m.parallel2.EXPECT().ParallelDone(ctx, time.Duration(1))
-			m.stack.ParallelInit(&ParallelInfo{"foo", "foo.go", 0, 0}).ParallelDone(ctx, time.Duration(1))
+			m.stack.ParallelInit(&cff.ParallelInfo{"foo", "foo.go", 0, 0}).ParallelDone(ctx, time.Duration(1))
 		})
 	})
 
@@ -193,16 +193,16 @@ func TestEmitterStack(t *testing.T) {
 			defer m.ctrl.Finish()
 
 			m.emitter1.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16},
-				&DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12},
+				&cff.TaskInfo{"foo", "foo.go", 14, 16},
+				&cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12},
 			).Times(1)
 			m.emitter2.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16},
-				&DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12},
+				&cff.TaskInfo{"foo", "foo.go", 14, 16},
+				&cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12},
 			).Times(1)
 			m.stack.TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16},
-				&DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12},
+				&cff.TaskInfo{"foo", "foo.go", 14, 16},
+				&cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12},
 			)
 		})
 
@@ -212,14 +212,14 @@ func TestEmitterStack(t *testing.T) {
 			defer m.ctrl.Finish()
 
 			m.emitter1.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task1)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task1)
 			m.emitter2.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task2)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task2)
 
 			m.task1.EXPECT().TaskSuccess(ctx)
 			m.task2.EXPECT().TaskSuccess(ctx)
 			m.stack.TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).TaskSuccess(ctx)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).TaskSuccess(ctx)
 		})
 		t.Run("TaskError", func(t *testing.T) {
 			ctx := context.Background()
@@ -227,16 +227,16 @@ func TestEmitterStack(t *testing.T) {
 			defer m.ctrl.Finish()
 
 			m.emitter1.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task1)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task1)
 			m.emitter2.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task2)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task2)
 
 			err := errors.New("foobar")
 
 			m.task1.EXPECT().TaskError(ctx, err)
 			m.task2.EXPECT().TaskError(ctx, err)
 			m.stack.TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).TaskError(ctx, err)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).TaskError(ctx, err)
 		})
 		t.Run("TaskErrorRecovered", func(t *testing.T) {
 			ctx := context.Background()
@@ -244,16 +244,16 @@ func TestEmitterStack(t *testing.T) {
 			defer m.ctrl.Finish()
 
 			m.emitter1.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task1)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task1)
 			m.emitter2.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task2)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task2)
 
 			err := errors.New("great sadness")
 
 			m.task1.EXPECT().TaskErrorRecovered(ctx, err)
 			m.task2.EXPECT().TaskErrorRecovered(ctx, err)
 			m.stack.TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).TaskErrorRecovered(ctx, err)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).TaskErrorRecovered(ctx, err)
 		})
 		t.Run("TaskSkipped", func(t *testing.T) {
 			ctx := context.Background()
@@ -261,16 +261,16 @@ func TestEmitterStack(t *testing.T) {
 			defer m.ctrl.Finish()
 
 			m.emitter1.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task1)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task1)
 			m.emitter2.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task2)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task2)
 
 			err := errors.New("foobar")
 
 			m.task1.EXPECT().TaskSkipped(ctx, err)
 			m.task2.EXPECT().TaskSkipped(ctx, err)
 			m.stack.TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).TaskSkipped(ctx, err)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).TaskSkipped(ctx, err)
 		})
 		t.Run("TaskPanic", func(t *testing.T) {
 			ctx := context.Background()
@@ -278,16 +278,16 @@ func TestEmitterStack(t *testing.T) {
 			defer m.ctrl.Finish()
 
 			m.emitter1.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task1)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task1)
 			m.emitter2.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task2)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task2)
 
 			pv := int(1)
 
 			m.task1.EXPECT().TaskPanic(ctx, pv)
 			m.task2.EXPECT().TaskPanic(ctx, pv)
 			m.stack.TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).TaskPanic(ctx, pv)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).TaskPanic(ctx, pv)
 		})
 		t.Run("TaskPanicRecovered", func(t *testing.T) {
 			ctx := context.Background()
@@ -295,16 +295,16 @@ func TestEmitterStack(t *testing.T) {
 			defer m.ctrl.Finish()
 
 			m.emitter1.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task1)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task1)
 			m.emitter2.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task2)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task2)
 
 			pv := int(1)
 
 			m.task1.EXPECT().TaskPanicRecovered(ctx, pv)
 			m.task2.EXPECT().TaskPanicRecovered(ctx, pv)
 			m.stack.TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).TaskPanicRecovered(ctx, pv)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).TaskPanicRecovered(ctx, pv)
 		})
 		t.Run("TaskDone", func(t *testing.T) {
 			ctx := context.Background()
@@ -312,14 +312,14 @@ func TestEmitterStack(t *testing.T) {
 			defer m.ctrl.Finish()
 
 			m.emitter1.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task1)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task1)
 			m.emitter2.EXPECT().TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).Return(m.task2)
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).Return(m.task2)
 
 			m.task1.EXPECT().TaskDone(ctx, time.Duration(1))
 			m.task2.EXPECT().TaskDone(ctx, time.Duration(1))
 			m.stack.TaskInit(
-				&TaskInfo{"foo", "foo.go", 14, 16}, &DirectiveInfo{"fooFlow", FlowDirective, "foo.go", 10, 12}).TaskDone(ctx, time.Duration(1))
+				&cff.TaskInfo{"foo", "foo.go", 14, 16}, &cff.DirectiveInfo{"fooFlow", cff.FlowDirective, "foo.go", 10, 12}).TaskDone(ctx, time.Duration(1))
 		})
 	})
 }

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -5,26 +5,26 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	. "go.uber.org/cff"
+	"go.uber.org/cff"
 	"go.uber.org/cff/internal/emittertest"
 )
 
 func TestAdaptSchedulerEmitter(t *testing.T) {
 	t.Parallel()
 
-	schedInfo := &SchedulerInfo{}
+	schedInfo := &cff.SchedulerInfo{}
 
 	t.Run("nil emitter", func(t *testing.T) {
-		assert.Nil(t, AdaptSchedulerEmitter(nil))
+		assert.Nil(t, cff.AdaptSchedulerEmitter(nil))
 	})
 
 	t.Run("no op emitter", func(t *testing.T) {
-		assert.Nil(t, AdaptSchedulerEmitter(NopEmitter().SchedulerInit(schedInfo)))
+		assert.Nil(t, cff.AdaptSchedulerEmitter(cff.NopEmitter().SchedulerInit(schedInfo)))
 	})
 
 	t.Run("live emitter", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		e := emittertest.NewMockSchedulerEmitter(ctrl)
-		assert.NotNil(t, AdaptSchedulerEmitter(e))
+		assert.NotNil(t, cff.AdaptSchedulerEmitter(e))
 	})
 }


### PR DESCRIPTION
Recent versions of golangci-lint and revive
complain about use of '.' imports.

```
emitter_stack_test.go:10:2: dot-imports: should not use dot imports (revive)
scheduler_test.go:8:2: dot-imports: should not use dot imports (revive)
```

Replace these uses with regular imports.
