### PR TITLE
coverage: Read coverage token in coverage step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,5 @@ jobs:
 
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
After 59bedc21b6ac6e463b02fe1dc3686b550cb636f9 landed we need to read the coverage token from the environment.