### PR TITLE
golangci: Run install step with --help

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       name: Install golangci-lint
       with:
         version: latest
-        args: --version  # make lint will run the linter
+        args: --help  # make lint will run the linter
 
     - run: make lint
       name: Lint


### PR DESCRIPTION
PR builds have been failing with an unknown flag error
```
run golangci-lint
  Running [/home/runner/golangci-lint-1.58.1-linux-amd64/golangci-lint run  --version] in [/home/runner/work/cff/cff] ...
  Error: unknown flag: --version
  Failed executing command with error: unknown flag: --version
```
ref: https://github.com/uber-go/cff/actions/runs/9061971983/job/24894837626?pr=96

--version is a valid flag for golangci-lint but not golangci-lint run.

For golangci-lint run, the closest no-op action is --help.

Fix golangci-lint runs by using the --help flag instead of the version flag.