### PR TITLE
lint: fix niliness typo in govet config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,10 +22,18 @@ linters:
     - revive
 
 linters-settings:
+  errcheck:
+    # fmt.Fprint* writes to stdout/stderr; the returned error is
+    # conventionally ignored because there's nowhere meaningful to
+    # redirect it.
+    exclude-functions:
+      - fmt.Fprint
+      - fmt.Fprintf
+      - fmt.Fprintln
   govet:
     # These govet checks are disabled by default, but they're useful.
     enable:
-      - niliness
+      - nilness
       - reflectvaluecompare
       - sortslice
       - unusedwrite


### PR DESCRIPTION
Fixes two latent issues in `.golangci.yml` that both surface under `golangci-lint` v1.64.x's stricter `config verify`. Currently breaking CI on every open PR — see [#105 Lint job](https://github.com/uber-go/cff/actions/runs/26027414246/job/76504261977).

## Changes

**1. `niliness` → `nilness`** (the govet analyzer name has no double `i`)

Typo introduced in [e66de90](https://github.com/uber-go/cff/commit/e66de90) (Sep 2023). Older `golangci-lint` versions silently ignored unknown analyzer names; v1.64.x rejects them during config verification:

